### PR TITLE
Add unit tests for deployment resource generations

### DIFF
--- a/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler.go
+++ b/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler.go
@@ -121,20 +121,20 @@ func makeCiliumNetworkPolicy(deployCtx *dataplane.DeploymentContext) *ciliumv2.C
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      makeCiliumNetworkPolicyName(deployCtx),
 			Namespace: makeNamespaceName(deployCtx),
-			Labels:    makeLabels(deployCtx),
+			Labels:    makeNamespaceLabels(deployCtx),
 		},
 		Spec: makeRuleAllowCommunicationWithinNamespaceOnly(),
 	}
 }
 
-// TODO: Unit test me
 func makeRuleAllowCommunicationWithinNamespaceOnly() *ciliumv2.Rule {
-	allEndpoints := ciliumv2.EndpointSelector{
-		MatchLabels: map[string]string{},
-	}
+	allEndpoints := ciliumv2.EndpointSelector{}
 
+	// Allow all pods in the namespace to communicate with each other
+	// The EndpointSelector is empty which means it selects all endpoints (pods) in the namespace
+	// The Egress and Ingress rules are defined to allow all pods in the namespace to communicate with each other
 	return &ciliumv2.Rule{
-		EndpointSelector: &ciliumv2.EndpointSelector{},
+		EndpointSelector: &allEndpoints,
 		Egress: []ciliumv2.EgressRule{
 			{
 				ToEndpoints: []ciliumv2.EndpointSelector{allEndpoints},

--- a/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler_test.go
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/choreo-idp/choreo/internal/dataplane"
+	ciliumv2 "github.com/choreo-idp/choreo/internal/dataplane/kubernetes/types/cilium.io/v2"
+)
+
+var _ = Describe("makeCiliumNetworkPolicy", func() {
+	var (
+		deployCtx *dataplane.DeploymentContext
+		cnp       *ciliumv2.CiliumNetworkPolicy
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		cnp = makeCiliumNetworkPolicy(deployCtx)
+	})
+
+	Context("when the DeploymentContext has valid Project and Environment", func() {
+
+		It("should create a CiliumNetworkPolicy with correct name and namespace", func() {
+			Expect(cnp).NotTo(BeNil())
+			Expect(cnp.Name).To(Equal("default-policy"))
+			Expect(cnp.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name": "test-organization",
+			"project-name":      "my-project",
+			"environment-name":  "development",
+			"managed-by":        "choreo-deployment-controller",
+			"belong-to":         "user-workloads",
+		}
+
+		It("should create a CiliumNetworkPolicy with valid labels", func() {
+			Expect(cnp.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a CiliumNetworkPolicy that allows communication between all pods within the namespace", func() {
+			allEndpointsSelector := ciliumv2.EndpointSelector{}
+			allowAllEgressRule := ciliumv2.EgressRule{ToEndpoints: []ciliumv2.EndpointSelector{allEndpointsSelector}}
+			allowAllIngressRule := ciliumv2.IngressRule{FromEndpoints: []ciliumv2.EndpointSelector{allEndpointsSelector}}
+
+			Expect(cnp.Spec.EndpointSelector).To(Equal(&allEndpointsSelector))
+			Expect(cnp.Spec.Egress).To(HaveLen(1))
+			Expect(cnp.Spec.Egress[0]).To(Equal(allowAllEgressRule))
+			Expect(cnp.Spec.Ingress).To(HaveLen(1))
+			Expect(cnp.Spec.Ingress[0]).To(Equal(allowAllIngressRule))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/cronjob_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/cronjob_handler_test.go
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	batchv1 "k8s.io/api/batch/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+	"github.com/choreo-idp/choreo/internal/ptr"
+)
+
+var _ = Describe("makeCronJob", func() {
+	var (
+		deployCtx *dataplane.DeploymentContext
+		cronJob   *batchv1.CronJob
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		cronJob = makeCronJob(deployCtx)
+	})
+
+	Context("for a ScheduledTask component", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeScheduledTask
+		})
+
+		It("should create a CronJob with correct name and namespace", func() {
+			Expect(cronJob).NotTo(BeNil())
+			Expect(cronJob.Name).To(Equal("my-component-my-main-track-a43a18e7"))
+			Expect(cronJob.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name":     "test-organization",
+			"project-name":          "my-project",
+			"environment-name":      "development",
+			"component-name":        "my-component",
+			"component-type":        "ScheduledTask",
+			"deployment-track-name": "my-main-track",
+			"deployment-name":       "my-deployment",
+			"managed-by":            "choreo-deployment-controller",
+			"belong-to":             "user-workloads",
+		}
+
+		It("should create a CronJob with valid labels", func() {
+			Expect(cronJob.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a CronJob with correct Job labels", func() {
+			Expect(cronJob.Spec.JobTemplate.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a CronJob with correct Pod labels", func() {
+			Expect(cronJob.Spec.JobTemplate.Spec.Template.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a CronJob with correct Spec", func() {
+			By("checking the schedule")
+			// This will be empty if the configuration is not provided
+			Expect(cronJob.Spec.Schedule).To(Equal(""))
+
+			By("checking the concurrency policy")
+			Expect(cronJob.Spec.ConcurrencyPolicy).To(Equal(batchv1.ForbidConcurrent))
+
+			By("checking the timezone")
+			Expect(cronJob.Spec.TimeZone).To(Equal(ptr.String("Etc/UTC")))
+		})
+
+		It("should create a CronJob with correct Job template", func() {
+			By("checking the ActiveDeadlineSeconds")
+			Expect(cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds).To(Equal(ptr.Int64(300)))
+
+			By("checking the BackoffLimit")
+			Expect(cronJob.Spec.JobTemplate.Spec.BackoffLimit).To(Equal(ptr.Int32(4)))
+
+			By("checking the TTLSecondsAfterFinished")
+			Expect(cronJob.Spec.JobTemplate.Spec.TTLSecondsAfterFinished).To(Equal(ptr.Int32(360)))
+		})
+
+		It("should create a CronJob with a correct container", func() {
+			containers := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers
+			By("checking the container length")
+			Expect(containers).To(HaveLen(1))
+
+			By("checking the container")
+			Expect(containers[0].Name).To(Equal("main"))
+			Expect(containers[0].Image).To(Equal("my-image:latest"))
+		})
+	})
+
+	Context("for a ScheduledTask component with a configuration", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeScheduledTask
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				Application: &choreov1.Application{
+					Task: &choreov1.TaskConfig{
+						Disabled: true,
+						Schedule: &choreov1.TaskSchedule{
+							Cron:     "*/5 * * * *",
+							Timezone: "Asia/Colombo",
+						},
+					},
+				},
+			}
+		})
+
+		It("should create a CronJob with correct schedule", func() {
+			Expect(cronJob.Spec.Schedule).To(Equal("*/5 * * * *"))
+		})
+
+		It("should create a CronJob with correct timezone", func() {
+			Expect(cronJob.Spec.TimeZone).To(Equal(ptr.String("Asia/Colombo")))
+		})
+
+		It("should create a CronJob with correct Suspend value", func() {
+			Expect(cronJob.Spec.Suspend).To(Equal(ptr.Bool(true)))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/deployment_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/deployment_handler_test.go
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+var _ = Describe("makeDeployment", func() {
+	var (
+		deployCtx  *dataplane.DeploymentContext
+		deployment *appsv1.Deployment
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		deployment = makeDeployment(deployCtx)
+	})
+
+	Context("for a Service component", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+		})
+
+		It("should create a Deployment with correct name and namespace", func() {
+			Expect(deployment).NotTo(BeNil())
+			Expect(deployment.Name).To(Equal("my-component-my-main-track-a43a18e7"))
+			Expect(deployment.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name":     "test-organization",
+			"project-name":          "my-project",
+			"environment-name":      "development",
+			"component-name":        "my-component",
+			"component-type":        "Service",
+			"deployment-track-name": "my-main-track",
+			"deployment-name":       "my-deployment",
+			"managed-by":            "choreo-deployment-controller",
+			"belong-to":             "user-workloads",
+		}
+
+		It("should create a Deployment with valid labels", func() {
+			Expect(deployment.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a Deployment with correct selector", func() {
+			Expect(deployment.Spec.Selector.MatchLabels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a Deployment with a correct container", func() {
+			containers := deployment.Spec.Template.Spec.Containers
+
+			By("checking the container length")
+			Expect(containers).To(HaveLen(1))
+
+			By("checking the container")
+			Expect(containers[0].Name).To(Equal("main"))
+			Expect(containers[0].Image).To(Equal("my-image:latest"))
+		})
+	})
+
+	Context("for a Service component with one TCP and one UDP endpoint", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				EndpointTemplates: []choreov1.EndpointTemplate{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-endpoint-tcp",
+						},
+						Spec: choreov1.EndpointSpec{
+							Type: choreov1.EndpointTypeREST,
+							Service: choreov1.EndpointServiceSpec{
+								BasePath: "/test",
+								Port:     8080,
+							},
+							NetworkVisibilities: []choreov1.NetworkVisibility{
+								choreov1.NetworkVisibilityPublic,
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-endpoint-udp",
+						},
+						Spec: choreov1.EndpointSpec{
+							Type: choreov1.EndpointTypeUDP,
+							Service: choreov1.EndpointServiceSpec{
+								Port: 8080,
+							},
+							NetworkVisibilities: []choreov1.NetworkVisibility{
+								choreov1.NetworkVisibilityPublic,
+							},
+						},
+					},
+				},
+			}
+
+		})
+
+		It("should create a Deployment with a correct container ports TCP and UDP", func() {
+			containers := deployment.Spec.Template.Spec.Containers
+			By("checking the container port length")
+			Expect(containers[0].Ports).To(HaveLen(2))
+
+			By("checking the TCP port")
+			Expect(containers[0].Ports[0].Name).To(Equal("ep-8080-tcp"))
+			Expect(containers[0].Ports[0].ContainerPort).To(Equal(int32(8080)))
+			Expect(containers[0].Ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+
+			By("checking the UDP port")
+			Expect(containers[0].Ports[1].Name).To(Equal("ep-8080-udp"))
+			Expect(containers[0].Ports[1].ContainerPort).To(Equal(int32(8080)))
+			Expect(containers[0].Ports[1].Protocol).To(Equal(corev1.ProtocolUDP))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/labels.go
+++ b/internal/controller/deployment/integrations/kubernetes/labels.go
@@ -24,22 +24,22 @@ import (
 	dpkubernetes "github.com/choreo-idp/choreo/internal/dataplane/kubernetes"
 )
 
-func makeLabels(deployCtx *dataplane.DeploymentContext) map[string]string {
+func makeNamespaceLabels(deployCtx *dataplane.DeploymentContext) map[string]string {
 	return map[string]string{
-		dpkubernetes.LabelKeyOrganizationName:    controller.GetOrganizationName(deployCtx.Project),
-		dpkubernetes.LabelKeyProjectName:         controller.GetName(deployCtx.Project),
-		dpkubernetes.LabelKeyComponentName:       controller.GetName(deployCtx.Component),
-		dpkubernetes.LabelKeyDeploymentTrackName: controller.GetName(deployCtx.DeploymentTrack),
-		dpkubernetes.LabelKeyEnvironmentName:     controller.GetName(deployCtx.Environment),
-		dpkubernetes.LabelKeyDeploymentName:      controller.GetName(deployCtx.Deployment),
-		dpkubernetes.LabelKeyManagedBy:           dpkubernetes.LabelValueManagedBy,
-		dpkubernetes.LabelKeyBelongTo:            dpkubernetes.LabelValueBelongTo,
+		dpkubernetes.LabelKeyOrganizationName: controller.GetOrganizationName(deployCtx.Project),
+		dpkubernetes.LabelKeyProjectName:      controller.GetName(deployCtx.Project),
+		dpkubernetes.LabelKeyEnvironmentName:  controller.GetName(deployCtx.Environment),
+		dpkubernetes.LabelKeyManagedBy:        dpkubernetes.LabelValueManagedBy,
+		dpkubernetes.LabelKeyBelongTo:         dpkubernetes.LabelValueBelongTo,
 	}
 }
 
 func makeWorkloadLabels(deployCtx *dataplane.DeploymentContext) map[string]string {
-	labels := makeLabels(deployCtx)
+	labels := makeNamespaceLabels(deployCtx)
+	labels[dpkubernetes.LabelKeyComponentName] = controller.GetName(deployCtx.Component)
 	labels[dpkubernetes.LabelKeyComponentType] = string(deployCtx.Component.Spec.Type)
+	labels[dpkubernetes.LabelKeyDeploymentTrackName] = controller.GetName(deployCtx.DeploymentTrack)
+	labels[dpkubernetes.LabelKeyDeploymentName] = controller.GetName(deployCtx.Deployment)
 	return labels
 }
 

--- a/internal/controller/deployment/integrations/kubernetes/namespace_handler.go
+++ b/internal/controller/deployment/integrations/kubernetes/namespace_handler.go
@@ -110,7 +110,7 @@ func makeNamespace(deployCtx *dataplane.DeploymentContext) *corev1.Namespace {
 	return &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   makeNamespaceName(deployCtx),
-			Labels: makeLabels(deployCtx),
+			Labels: makeNamespaceLabels(deployCtx),
 		},
 	}
 }

--- a/internal/controller/deployment/integrations/kubernetes/namespace_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/namespace_handler_test.go
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+var _ = Describe("makeNamespace", func() {
+	var (
+		deployCtx *dataplane.DeploymentContext
+		namespace *corev1.Namespace
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		namespace = makeNamespace(deployCtx)
+	})
+
+	Context("when the DeploymentContext has valid Project and Environment", func() {
+
+		It("should create a Namespace with valid name", func() {
+			Expect(namespace).NotTo(BeNil())
+			Expect(namespace.Name).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name": "test-organization",
+			"project-name":      "my-project",
+			"environment-name":  "development",
+			"managed-by":        "choreo-deployment-controller",
+			"belong-to":         "user-workloads",
+		}
+
+		It("should create a Namespace with valid labels", func() {
+			Expect(namespace.Labels).To(BeComparableTo(expectedLabels))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/service_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/service_handler_test.go
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+var _ = Describe("makeService", func() {
+	var (
+		deployCtx *dataplane.DeploymentContext
+		service   *corev1.Service
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		service = makeService(deployCtx)
+	})
+
+	Context("for a Service component with one endpoint", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				EndpointTemplates: []choreov1.EndpointTemplate{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-service-endpoint",
+						},
+						Spec: choreov1.EndpointSpec{
+							Type: choreov1.EndpointTypeREST,
+							Service: choreov1.EndpointServiceSpec{
+								BasePath: "/test",
+								Port:     8080,
+							},
+							NetworkVisibilities: []choreov1.NetworkVisibility{
+								choreov1.NetworkVisibilityPublic,
+							},
+						},
+					},
+				},
+			}
+
+		})
+
+		It("should create a Service with correct name and namespace", func() {
+			Expect(service).NotTo(BeNil())
+			Expect(service.Name).To(Equal("my-component-my-main-track-a43a18e7"))
+			Expect(service.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name":     "test-organization",
+			"project-name":          "my-project",
+			"environment-name":      "development",
+			"component-name":        "my-component",
+			"component-type":        "Service",
+			"deployment-track-name": "my-main-track",
+			"deployment-name":       "my-deployment",
+			"managed-by":            "choreo-deployment-controller",
+			"belong-to":             "user-workloads",
+		}
+
+		It("should create a Service with valid labels", func() {
+			Expect(service.Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a Service with correct selector", func() {
+			Expect(service.Spec.Selector).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create a Service with a correct port", func() {
+			ports := service.Spec.Ports
+
+			By("checking the port length")
+			Expect(ports).To(HaveLen(1))
+
+			By("checking the port")
+			Expect(ports[0].Name).To(Equal("ep-8080-tcp"))
+			Expect(ports[0].Port).To(Equal(int32(8080)))
+			Expect(ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+		})
+	})
+
+	Context("for a Service component with one TCP and one UDP endpoint", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				EndpointTemplates: []choreov1.EndpointTemplate{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-service-endpoint-tcp",
+						},
+						Spec: choreov1.EndpointSpec{
+							Type: choreov1.EndpointTypeREST,
+							Service: choreov1.EndpointServiceSpec{
+								BasePath: "/test",
+								Port:     8080,
+							},
+							NetworkVisibilities: []choreov1.NetworkVisibility{
+								choreov1.NetworkVisibilityPublic,
+							},
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "my-service-endpoint-udp",
+						},
+						Spec: choreov1.EndpointSpec{
+							Type: choreov1.EndpointTypeUDP,
+							Service: choreov1.EndpointServiceSpec{
+								Port: 8080,
+							},
+							NetworkVisibilities: []choreov1.NetworkVisibility{
+								choreov1.NetworkVisibilityPublic,
+							},
+						},
+					},
+				},
+			}
+
+		})
+
+		It("should create a Service with a correct port TCP and UDP port", func() {
+			ports := service.Spec.Ports
+
+			By("checking the port length")
+			Expect(ports).To(HaveLen(2))
+
+			By("checking the TCP port")
+			Expect(ports[0].Name).To(Equal("ep-8080-tcp"))
+			Expect(ports[0].Port).To(Equal(int32(8080)))
+			Expect(ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
+
+			By("checking the UDP port")
+			Expect(ports[1].Name).To(Equal("ep-8080-udp"))
+			Expect(ports[1].Port).To(Equal(int32(8080)))
+			Expect(ports[1].Protocol).To(Equal(corev1.ProtocolUDP))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/suite_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/suite_test.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+	"github.com/choreo-idp/choreo/internal/labels"
+)
+
+func TestDeploymentIntegrationKubernetes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Deployment Integration Kubernetes Suite")
+}
+
+// Create a new DeploymentContext for testing. Each test should create a new context
+// and set the required fields for the test.
+func newTestDeploymentContext() *dataplane.DeploymentContext {
+	deployCtx := &dataplane.DeploymentContext{}
+
+	deployCtx.Project = &choreov1.Project{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-project",
+			Namespace: "test-organization",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName: "test-organization",
+				labels.LabelKeyName:             "my-project",
+			},
+		},
+	}
+	deployCtx.Environment = &choreov1.Environment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "development",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName: "test-organization",
+				labels.LabelKeyName:             "development",
+			},
+		},
+	}
+	deployCtx.Component = &choreov1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-component",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName: "test-organization",
+				labels.LabelKeyProjectName:      "my-project",
+				labels.LabelKeyName:             "my-component",
+			},
+		},
+	}
+	deployCtx.DeploymentTrack = &choreov1.DeploymentTrack{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-main-track",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName: "test-organization",
+				labels.LabelKeyProjectName:      "my-project",
+				labels.LabelKeyComponentName:    "my-component",
+				labels.LabelKeyName:             "my-main-track",
+			},
+		},
+	}
+	deployCtx.DeployableArtifact = &choreov1.DeployableArtifact{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-artifact",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName:    "test-organization",
+				labels.LabelKeyProjectName:         "my-project",
+				labels.LabelKeyComponentName:       "my-component",
+				labels.LabelKeyDeploymentTrackName: "my-main-track",
+				labels.LabelKeyName:                "my-artifact",
+			},
+		},
+	}
+
+	deployCtx.Deployment = &choreov1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-deployment",
+			Namespace: "test-namespace",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName:    "test-organization",
+				labels.LabelKeyProjectName:         "my-project",
+				labels.LabelKeyEnvironmentName:     "my-environment",
+				labels.LabelKeyComponentName:       "my-component",
+				labels.LabelKeyDeploymentTrackName: "my-main-track",
+				labels.LabelKeyName:                "my-deployment",
+			},
+		},
+	}
+
+	deployCtx.ContainerImage = "my-image:latest"
+
+	return deployCtx
+}

--- a/internal/dataplane/kubernetes/suite_test.go
+++ b/internal/dataplane/kubernetes/suite_test.go
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestDataPlaneKubernetes(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Data Plane Kubernetes Suite")
+}


### PR DESCRIPTION
## Purpose
Add unit tests for deployment resource generations

## Approach
This PR includes unit testing for the Kubernetes data plane resource generation functions via the deployment controller.
Additionally, this updates the previous unit tests in this package from go native tests to ginkgo tests.

Coverage before:
```bash
$ go test -cover ./internal/controller/deployment/integrations/kubernetes
ok      github.com/choreo-idp/choreo/internal/controller/deployment/integrations/kubernetes     0.975s  coverage: 7.6% of statements
```

Coverage after:
```bash
$ go test -cover ./internal/controller/deployment/integrations/kubernetes
ok      github.com/choreo-idp/choreo/internal/controller/deployment/integrations/kubernetes     0.888s  coverage: 32.3% of statements
```

## Related Issues
- https://github.com/choreo-idp/choreo/issues/11

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
