### PR TITLE
Add default resources

### DIFF
--- a/install/helm/choreo/templates/default-choreo-artifacts/environments.yaml
+++ b/install/helm/choreo/templates/default-choreo-artifacts/environments.yaml
@@ -17,6 +17,7 @@ metadata:
 spec:
   dataPlaneRef: {{ $.Values.choreoDefaultValues.dataPlane.name }}
   isProduction: {{ .isCritical }}
-  dnsPrefix: {{ .dnsPrefix }}
+  gateway:
+    dnsPrefix: {{ .dnsPrefix }}
 {{- end }}
 {{ end }}

--- a/samples/default-resources.yaml
+++ b/samples/default-resources.yaml
@@ -1,0 +1,135 @@
+## Sample Organization kind (Cluster-scoped)
+apiVersion: core.choreo.dev/v1
+kind: Organization
+metadata:
+  name: default-org
+  annotations:
+    core.choreo.dev/display-name: Default Organization
+    core.choreo.dev/description: Getting started with your first organization
+  labels:
+    core.choreo.dev/name: default-org
+spec:
+---
+
+## Sample DataPlane kind (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: DataPlane
+metadata:
+  name: default-dataplane
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Default Data Plane
+    core.choreo.dev/description: Local development data plane
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: default-dataplane
+spec:
+  kubernetesCluster:
+    name: kind-cluster-1
+    connectionConfigRef: kind-cluster-1-connection-config
+    featureFlags:
+      cilium: true
+      scaleToZero: true
+      gatewayType: envoy
+  gateway:
+    publicVirtualHost: choreoapis.local
+    organizationVirtualHost: internal.choreoapis.local
+---
+
+## Sample DeploymentPipeline kind (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: DeploymentPipeline
+metadata:
+  name: default-pipeline
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Default Pipeline
+    core.choreo.dev/description: Standard deployment pipeline with dev, staging, and prod environments
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: default-pipeline
+spec:
+  promotionPaths:
+    - sourceEnvironmentRef: development
+      targetEnvironmentRefs:
+        - name: staging
+          requiresApproval: false
+        - name: production
+          isManualApprovalRequired: true
+    - sourceEnvironmentRef: staging
+      targetEnvironmentRefs:
+        - name: production
+          requiresApproval: true
+---
+
+## Sample Environment kind - Development (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: Environment
+metadata:
+  name: development
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Development Environment
+    core.choreo.dev/description: Development environment for testing
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: development
+spec:
+  dataPlaneRef: default-dataplane
+  isProduction: false
+  gateway:
+    dnsPrefix: dev
+---
+
+## Sample Environment kind - Staging (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: Environment
+metadata:
+  name: staging
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Staging Environment
+    core.choreo.dev/description: Staging environment for pre-production testing
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: staging
+spec:
+  dataPlaneRef: default-dataplane
+  isProduction: false
+  gateway:
+    dnsPrefix: staging
+---
+
+## Sample Environment kind - Production (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: Environment
+metadata:
+  name: production
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Production Environment
+    core.choreo.dev/description: Production environment
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: production
+spec:
+  dataPlaneRef: default-dataplane
+  isProduction: true
+  gateway:
+    dnsPrefix: prod
+---
+
+## Sample Project kind (Namespaced)
+apiVersion: core.choreo.dev/v1
+kind: Project
+metadata:
+  name: default-project
+  namespace: default-org
+  annotations:
+    core.choreo.dev/display-name: Default Project
+    core.choreo.dev/description: Your first project to get started
+  labels:
+    core.choreo.dev/organization: default-org
+    core.choreo.dev/name: default-project
+spec:
+  deploymentPipelineRef: default-pipeline


### PR DESCRIPTION
## Purpose
When creating a cluster from scratch, these default resources may not be automatically created. 

Therefore, default resources are sometimes necessary during development to ensure smooth operation. However, when creating a cluster from scratch, these default resources may not be automatically created.

## Approach
Added default resources into samples. Users can apply if needed.

## Related Issues
https://github.com/choreo-idp/choreo/issues/38

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
