### PR TITLE
Fix build failure due to workflow name exceeding 63 character limit

### DIFF
--- a/internal/controller/build/workflow.go
+++ b/internal/controller/build/workflow.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	dpkubernetes "github.com/choreo-idp/choreo/internal/dataplane/kubernetes"
 	argo "github.com/choreo-idp/choreo/internal/dataplane/kubernetes/types/argoproj.io/workflow/v1alpha1"
 	"github.com/choreo-idp/choreo/internal/ptr"
 )
@@ -34,7 +35,7 @@ import (
 func makeArgoWorkflow(build *choreov1.Build, repo string, buildNamespace string) *argo.Workflow {
 	workflow := argo.Workflow{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      build.ObjectMeta.Name,
+			Name:      dpkubernetes.GenerateK8sNameWithLengthLimit(63, build.ObjectMeta.Name),
 			Namespace: buildNamespace,
 		},
 		Spec: makeWorkflowSpec(build, repo),


### PR DESCRIPTION
## Purpose
We encountered an error when the build name was too long, as the workflow name was derived from the build name. Argo Workflows has a limitation of 63 characters for the workflow name. This PR enforces a 63-character limit on workflow names to resolve the issue.

## Approach
> Summarize the solution and implementation details.

## Related Issues
https://github.com/choreo-idp/choreo/issues/42

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
