### PR TITLE
Fix deep copying in endpoint controller

### DIFF
--- a/internal/controller/endpoint/controller.go
+++ b/internal/controller/endpoint/controller.go
@@ -57,11 +57,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	// Get Endpoint CR
 	ep := &choreov1.Endpoint{}
-	old := ep.DeepCopy()
-
 	if err := r.Get(ctx, req.NamespacedName, ep); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
+
+	old := ep.DeepCopy()
 
 	if ep.Labels == nil {
 		logger.Info("Endpoint labels not set.")


### PR DESCRIPTION
## Purpose
Fix deep copying in endpoint controller

## Approach
This PR fixes the problem of creating an empty old object copy object before the read, which causes issues during status updates due to an empty old object.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
