### PR TITLE
Fix panic caused by direct type assertion return

### DIFF
--- a/internal/controller/build/controller.go
+++ b/internal/controller/build/controller.go
@@ -452,7 +452,11 @@ func (r *Reconciler) fetchComponentConfigs(ctx context.Context, buildCtx *integr
 		logger.Error(err, "Failed to fetch component descriptor")
 		return nil, fmt.Errorf("failed to get component.yaml from the repository buildName:%s;%w", buildCtx.Build.Name, err)
 	}
-	return config.(*source.Config), nil
+	sourceConfig, ok := config.(source.Config)
+	if !ok {
+		return nil, fmt.Errorf("unexpected type for component descriptor: %T", config)
+	}
+	return &sourceConfig, nil
 }
 
 func (r *Reconciler) getEndpointConfigs(ctx context.Context, buildCtx *integrations.BuildContext) ([]choreov1.EndpointTemplate, error) {

--- a/internal/controller/build/controller.go
+++ b/internal/controller/build/controller.go
@@ -452,11 +452,7 @@ func (r *Reconciler) fetchComponentConfigs(ctx context.Context, buildCtx *integr
 		logger.Error(err, "Failed to fetch component descriptor")
 		return nil, fmt.Errorf("failed to get component.yaml from the repository buildName:%s;%w", buildCtx.Build.Name, err)
 	}
-	sourceConfig, ok := config.(source.Config)
-	if !ok {
-		return nil, fmt.Errorf("unexpected type for component descriptor: %T", config)
-	}
-	return &sourceConfig, nil
+	return config, nil
 }
 
 func (r *Reconciler) getEndpointConfigs(ctx context.Context, buildCtx *integrations.BuildContext) ([]choreov1.EndpointTemplate, error) {

--- a/internal/controller/build/integrations/source/github/github.go
+++ b/internal/controller/build/integrations/source/github/github.go
@@ -27,7 +27,7 @@ func (h *githubHandler) Name(ctx context.Context, builtCtx *integrations.BuildCo
 	return "SourceGithub"
 }
 
-func (h *githubHandler) FetchComponentDescriptor(ctx context.Context, buildCtx *integrations.BuildContext) (interface{}, error) {
+func (h *githubHandler) FetchComponentDescriptor(ctx context.Context, buildCtx *integrations.BuildContext) (*source.Config, error) {
 	owner, repositoryName, err := source.ExtractRepositoryInfo(buildCtx.Component.Spec.Source.GitRepository.URL)
 	if err != nil {
 		return nil, fmt.Errorf("bad git repository url: %w", err)
@@ -53,5 +53,5 @@ func (h *githubHandler) FetchComponentDescriptor(ctx context.Context, buildCtx *
 		return nil, fmt.Errorf("failed to unmarshal component.yaml from the repository buildName:%s;owner:%s;repo:%s;%w", buildCtx.Build.Name, owner, repositoryName, err)
 	}
 
-	return config, nil
+	return &config, nil
 }

--- a/internal/controller/build/integrations/source/interfaces.go
+++ b/internal/controller/build/integrations/source/interfaces.go
@@ -1,6 +1,8 @@
 package source
 
-import "context"
+import (
+	"context"
+)
 
 // SourceHandler is an interface that defines the operations that can be performed on the source provider
 // (GitHub/BitBucket/GitLab/etc.) by the build controller during the reconciliation process.
@@ -9,5 +11,5 @@ type SourceHandler[T any] interface {
 	Name(ctx context.Context, resourceCtx *T) string
 
 	// FetchComponentDescriptor fetches the component yaml from the source repository.
-	FetchComponentDescriptor(ctx context.Context, resourceCtx *T) (interface{}, error)
+	FetchComponentDescriptor(ctx context.Context, resourceCtx *T) (*Config, error)
 }


### PR DESCRIPTION
## Purpose
Fix a panic that occurs when directly returning the result of a type assertion.

## Approach
Added a type assertion check to handle the error gracefully and prevent the panic.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
