### PR TITLE
Add env var injection via the config groups

### DIFF
--- a/internal/controller/deployment/deployment_context.go
+++ b/internal/controller/deployment/deployment_context.go
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package deployment
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slabels "k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/controller"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+	"github.com/choreo-idp/choreo/internal/labels"
+)
+
+// makeDeploymentContext creates a deployment context for the given deployment by retrieving the
+// parent objects that this deployment is associated with.
+func (r *Reconciler) makeDeploymentContext(ctx context.Context, deployment *choreov1.Deployment) (*dataplane.DeploymentContext, error) {
+	project, err := controller.GetProject(ctx, r.Client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the project: %w", err)
+	}
+
+	component, err := controller.GetComponent(ctx, r.Client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the component: %w", err)
+	}
+
+	deploymentTrack, err := controller.GetDeploymentTrack(ctx, r.Client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the deployment track: %w", err)
+	}
+
+	environment, err := controller.GetEnvironment(ctx, r.Client, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the environment: %w", err)
+	}
+
+	targetDeployableArtifact, err := r.findDeployableArtifact(ctx, deployment)
+	if err != nil {
+		meta.SetStatusCondition(&deployment.Status.Conditions,
+			NewArtifactNotFoundCondition(deployment.Spec.DeploymentArtifactRef, deployment.Generation))
+		return nil, fmt.Errorf("cannot retrieve the deployable artifact: %w", err)
+	}
+
+	containerImage, err := r.findContainerImage(ctx, component, targetDeployableArtifact, deployment)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the container image: %w", err)
+	}
+
+	configurationGroups, err := r.findConfigurationGroups(ctx, targetDeployableArtifact)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve the referenced configuration groups: %w", err)
+	}
+
+	meta.SetStatusCondition(&deployment.Status.Conditions, NewArtifactResolvedCondition(deployment.Generation))
+
+	return &dataplane.DeploymentContext{
+		Project:             project,
+		Component:           component,
+		DeploymentTrack:     deploymentTrack,
+		DeployableArtifact:  targetDeployableArtifact,
+		Deployment:          deployment,
+		Environment:         environment,
+		ConfigurationGroups: configurationGroups,
+		ContainerImage:      containerImage,
+	}, nil
+}
+
+func (r *Reconciler) findDeployableArtifact(ctx context.Context, deployment *choreov1.Deployment) (*choreov1.DeployableArtifact, error) {
+	// Find the DeployableArtifact that the Deployment is referring to within the hierarchy
+	deployableArtifactList := &choreov1.DeployableArtifactList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(deployment.Namespace),
+		client.MatchingLabels(makeHierarchyLabelsForDeploymentTrack(deployment.ObjectMeta)),
+	}
+	if err := r.Client.List(ctx, deployableArtifactList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	// Find the target deployable artifact
+	var targetDeployableArtifact *choreov1.DeployableArtifact
+	for _, deployableArtifact := range deployableArtifactList.Items {
+		if deployableArtifact.Name == deployment.Spec.DeploymentArtifactRef {
+			targetDeployableArtifact = &deployableArtifact
+			break
+		}
+	}
+
+	if targetDeployableArtifact == nil {
+		return nil, fmt.Errorf("deployable artifact %q is not found for deployment: %s/%s", deployment.Spec.DeploymentArtifactRef, deployment.Namespace, deployment.Name)
+	}
+
+	return targetDeployableArtifact, nil
+}
+
+func makeHierarchyLabelsForDeploymentTrack(objMeta metav1.ObjectMeta) map[string]string {
+	// Hierarchical labels to be used for DeploymentTrack
+	keys := []string{
+		labels.LabelKeyOrganizationName,
+		labels.LabelKeyProjectName,
+		labels.LabelKeyComponentName,
+		labels.LabelKeyDeploymentTrackName,
+	}
+
+	// Prepare a new map to hold the extracted labels.
+	hierarchyLabelMap := make(map[string]string, len(keys))
+
+	for _, key := range keys {
+		// We need to assign an empty string if the label is not present.
+		// Otherwise, the k8s listing will return all the objects.
+		val := ""
+		if objMeta.Labels != nil {
+			val = objMeta.Labels[key]
+		}
+		hierarchyLabelMap[key] = val
+	}
+
+	return hierarchyLabelMap
+}
+
+func (r *Reconciler) findContainerImage(ctx context.Context, component *choreov1.Component,
+	deployableArtifact *choreov1.DeployableArtifact, deployment *choreov1.Deployment) (string, error) {
+	if buildRef := deployableArtifact.Spec.TargetArtifact.FromBuildRef; buildRef != nil {
+		if buildRef.Name != "" {
+			// Find the build that the deployable artifact is referring to
+			buildList := &choreov1.BuildList{}
+			listOpts := []client.ListOption{
+				client.InNamespace(deployableArtifact.Namespace),
+				client.MatchingLabels(makeHierarchyLabelsForDeploymentTrack(deployableArtifact.ObjectMeta)),
+			}
+			if err := r.Client.List(ctx, buildList, listOpts...); err != nil {
+				return "", fmt.Errorf("findContainerImage: failed to list builds: %w", err)
+			}
+
+			for _, build := range buildList.Items {
+				if build.Name == buildRef.Name {
+					// TODO: Make local registry configurable and move to build controller
+					return fmt.Sprintf("%s/%s", "localhost:30003", build.Status.ImageStatus.Image), nil
+				}
+			}
+			meta.SetStatusCondition(&deployment.Status.Conditions,
+				NewArtifactBuildNotFoundCondition(deployment.Spec.DeploymentArtifactRef, buildRef.Name, deployment.Generation))
+			return "", fmt.Errorf("build %q is not found for deployable artifact: %s/%s", buildRef.Name, deployableArtifact.Namespace, deployableArtifact.Name)
+		} else if buildRef.GitRevision != "" {
+			// TODO: Search for the build by git revision
+			return "", fmt.Errorf("search by git revision is not supported")
+		}
+		return "", fmt.Errorf("one of the build name or git revision should be provided")
+	} else if imageRef := deployableArtifact.Spec.TargetArtifact.FromImageRef; imageRef != nil {
+		if imageRef.Tag == "" {
+			return "", fmt.Errorf("image tag is not provided")
+		}
+		containerRegistry := component.Spec.Source.ContainerRegistry
+		if containerRegistry == nil {
+			return "", fmt.Errorf("container registry is not provided for the component %s/%s", component.Namespace, component.Name)
+		}
+		return fmt.Sprintf("%s:%s", containerRegistry.ImageName, imageRef.Tag), nil
+	}
+	return "", fmt.Errorf("one of the build or image reference should be provided")
+}
+
+func (r *Reconciler) findConfigurationGroups(ctx context.Context, deployableArtifact *choreov1.DeployableArtifact) ([]*choreov1.ConfigurationGroup, error) {
+	// Find all the ConfigurationGroups that the deployable artifact is referring to
+	if deployableArtifact.Spec.Configuration == nil || deployableArtifact.Spec.Configuration.Application == nil {
+		return nil, nil
+	}
+
+	appCfg := deployableArtifact.Spec.Configuration.Application
+	configGroupNameSet := make(map[string]struct{})
+
+	// The following individual loops will build the referenced configuration group names
+	// from the Env, EnvFrom, FileMounts, and FileMountsFrom sections of the application configuration.
+
+	// Find configuration groups in the Env section
+	for _, ev := range appCfg.Env {
+		if ev.ValueFrom == nil {
+			continue
+		}
+		if ev.ValueFrom.ConfigurationGroupRef == nil {
+			continue
+		}
+		if ev.ValueFrom.ConfigurationGroupRef.Name == "" {
+			continue // TODO: This will be validated by the admission controller
+		}
+		configGroupNameSet[ev.ValueFrom.ConfigurationGroupRef.Name] = struct{}{}
+	}
+
+	// Find configuration groups in the EnvFrom section
+	for _, evf := range appCfg.EnvFrom {
+		if evf.ConfigurationGroupRef == nil {
+			continue
+		}
+		if evf.ConfigurationGroupRef.Name == "" {
+			continue // TODO: This will be validated by the admission controller
+		}
+		configGroupNameSet[evf.ConfigurationGroupRef.Name] = struct{}{}
+	}
+
+	// Find configuration groups in the FileMounts section
+	for _, fm := range appCfg.FileMounts {
+		if fm.ValueFrom == nil {
+			continue
+		}
+		if fm.ValueFrom.ConfigurationGroupRef == nil {
+			continue
+		}
+		if fm.ValueFrom.ConfigurationGroupRef.Name == "" {
+			continue // TODO: This will be validated by the admission controller
+		}
+		configGroupNameSet[fm.ValueFrom.ConfigurationGroupRef.Name] = struct{}{}
+	}
+
+	// Find configuration groups in the FileMountsFrom section
+	for _, fmf := range appCfg.FileMountsFrom {
+		if fmf.ConfigurationGroupRef == nil {
+			continue
+		}
+		if fmf.ConfigurationGroupRef.Name == "" {
+			continue // TODO: This will be validated by the admission controller
+		}
+		configGroupNameSet[fmf.ConfigurationGroupRef.Name] = struct{}{}
+	}
+
+	// Build the label selector to find the configuration groups
+	configGroupNames := make([]string, 0, len(configGroupNameSet))
+	for name := range configGroupNameSet {
+		configGroupNames = append(configGroupNames, name)
+	}
+
+	req, err := k8slabels.NewRequirement(labels.LabelKeyName, selection.In, configGroupNames)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build the label selector: %w", err)
+	}
+	selector := k8slabels.NewSelector().Add(*req)
+
+	configurationGroupList := &choreov1.ConfigurationGroupList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(deployableArtifact.Namespace),
+		client.MatchingLabels(map[string]string{
+			labels.LabelKeyOrganizationName: deployableArtifact.Labels[labels.LabelKeyOrganizationName],
+		}),
+		client.MatchingLabelsSelector{
+			Selector: selector,
+		},
+	}
+	if err := r.Client.List(ctx, configurationGroupList, listOpts...); err != nil {
+		return nil, err
+	}
+
+	cgs := make([]*choreov1.ConfigurationGroup, 0, len(configurationGroupList.Items))
+	for _, item := range configurationGroupList.Items {
+		cgs = append(cgs, &item)
+	}
+
+	return cgs, nil
+}

--- a/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/cilium_network_policy_handler_test.go
@@ -46,13 +46,13 @@ var _ = Describe("makeCiliumNetworkPolicy", func() {
 		It("should create a CiliumNetworkPolicy with correct name and namespace", func() {
 			Expect(cnp).NotTo(BeNil())
 			Expect(cnp.Name).To(Equal("default-policy"))
-			Expect(cnp.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+			Expect(cnp.Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
 		})
 
 		expectedLabels := map[string]string{
 			"organization-name": "test-organization",
 			"project-name":      "my-project",
-			"environment-name":  "development",
+			"environment-name":  "test-environment",
 			"managed-by":        "choreo-deployment-controller",
 			"belong-to":         "user-workloads",
 		}

--- a/internal/controller/deployment/integrations/kubernetes/config_group.go
+++ b/internal/controller/deployment/integrations/kubernetes/config_group.go
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	"regexp"
+	"strings"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/controller"
+)
+
+// This file contains the helper functions that are related to deploying configuration groups in Kubernetes.
+
+// findConfigGroupByName returns the first matching configuration group with the given name.
+// If no matching configuration group is found, it returns nil.
+func findConfigGroupByName(configGroups []*choreov1.ConfigurationGroup, name string) *choreov1.ConfigurationGroup {
+	for _, cg := range configGroups {
+		if controller.GetName(cg) == name {
+			return cg
+		}
+	}
+	return nil
+}
+
+// findConfigGroupValueForEnv returns the configuration value for the given environment
+// from the given configuration value list. Returns nil if no matching configuration value is found.
+func findConfigGroupValueForEnv(value []choreov1.ConfigurationValue,
+	envGroup []choreov1.EnvironmentGroup, env *choreov1.Environment) *choreov1.ConfigurationValue {
+	for _, v := range value {
+		envName := controller.GetName(env)
+		if v.Environment == envName {
+			return &v
+		}
+		// If the environment group reference is set,
+		// find if there is a value for the environment in the environment group
+		for _, eg := range envGroup {
+			if eg.Name == v.EnvironmentGroupRef {
+				for _, ege := range eg.Environments {
+					if ege == envName {
+						return &v
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+var invalidEnvKeyChars = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
+func sanitizeEnvVarKey(key string) string {
+	// Replace invalid characters with underscore.
+	newKey := strings.ToUpper(invalidEnvKeyChars.ReplaceAllString(key, "_"))
+
+	// If the result is empty, return a default key.
+	if len(newKey) == 0 {
+		return ""
+	}
+
+	// Ensure the first character is a letter or an underscore.
+	// Example: "123" -> "_123"
+	first := newKey[0]
+	if !(first >= 'A' && first <= 'Z' || first == '_') {
+		newKey = "_" + newKey
+	}
+	return newKey
+}

--- a/internal/controller/deployment/integrations/kubernetes/configmap_handler.go
+++ b/internal/controller/deployment/integrations/kubernetes/configmap_handler.go
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/google/go-cmp/cmp"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+	dpkubernetes "github.com/choreo-idp/choreo/internal/dataplane/kubernetes"
+)
+
+type configMapHandler struct {
+	kubernetesClient client.Client
+}
+
+var _ dataplane.ResourceHandler[dataplane.DeploymentContext] = (*configMapHandler)(nil)
+
+func NewConfigMapHandler(kubernetesClient client.Client) dataplane.ResourceHandler[dataplane.DeploymentContext] {
+	return &configMapHandler{
+		kubernetesClient: kubernetesClient,
+	}
+}
+
+func (h *configMapHandler) Name() string {
+	return "KubernetesConfigMapHandler"
+}
+
+func (h *configMapHandler) IsRequired(deployCtx *dataplane.DeploymentContext) bool {
+	return len(deployCtx.ConfigurationGroups) > 0
+}
+
+func (h *configMapHandler) GetCurrentState(ctx context.Context, deployCtx *dataplane.DeploymentContext) (interface{}, error) {
+	namespace := makeNamespaceName(deployCtx)
+	labels := makeWorkloadLabels(deployCtx)
+	cmList := &corev1.ConfigMapList{}
+	listOpts := []client.ListOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels),
+	}
+	err := h.kubernetesClient.List(ctx, cmList, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(cmList.Items) == 0 {
+		return nil, nil
+	}
+	// Convert the list to a slice of pointers so that it can be compared with the new state
+	// during the update operation
+	configMaps := make([]*corev1.ConfigMap, 0, len(cmList.Items))
+	for i := range cmList.Items {
+		configMaps = append(configMaps, &cmList.Items[i])
+	}
+	return configMaps, nil
+}
+
+func (h *configMapHandler) Create(ctx context.Context, deployCtx *dataplane.DeploymentContext) error {
+	configMaps := makeConfigMaps(deployCtx)
+	for _, cm := range configMaps {
+		err := h.kubernetesClient.Create(ctx, cm)
+		if err != nil {
+			return fmt.Errorf("error while creating configmap %s: %w", cm.Name, err)
+		}
+	}
+	return nil
+}
+
+func (h *configMapHandler) Update(ctx context.Context, deployCtx *dataplane.DeploymentContext, currentState interface{}) error {
+	currentConfigMaps, ok := currentState.([]*corev1.ConfigMap)
+	if !ok {
+		return errors.New("failed to cast current state to a slice of ConfigMaps")
+	}
+
+	desiredConfigMaps := makeConfigMaps(deployCtx)
+
+	// Build a map for quick lookups of current and desired ConfigMaps
+	// Using "name" as the key
+	currentMap := make(map[string]*corev1.ConfigMap, len(currentConfigMaps))
+	for _, cm := range currentConfigMaps {
+		currentMap[cm.Name] = cm
+	}
+
+	desiredMap := make(map[string]*corev1.ConfigMap, len(desiredConfigMaps))
+	for _, cm := range desiredConfigMaps {
+		desiredMap[cm.Name] = cm
+	}
+
+	// Create or update the ConfigMaps that are not present in the current state
+	for name, desiredConfigMap := range desiredMap {
+		existingConfigMap, found := currentMap[name]
+		if !found {
+			// Create the ConfigMap if it is not present in the current state
+			if err := h.kubernetesClient.Create(ctx, desiredConfigMap); err != nil {
+				return fmt.Errorf("error while creating configmap %s: %w", desiredConfigMap.Name, err)
+			}
+			continue
+		}
+
+		// Update the ConfigMaps that are present in the current state
+		if !cmp.Equal(existingConfigMap.Data, desiredConfigMap.Data) ||
+			!cmp.Equal(extractManagedLabels(existingConfigMap.Labels), extractManagedLabels(desiredConfigMap.Labels)) {
+			// TODO: Auto restart the pods that are using the ConfigMap
+			updatedConfigMap := existingConfigMap.DeepCopy()
+			updatedConfigMap.Data = desiredConfigMap.Data
+			updatedConfigMap.Labels = desiredConfigMap.Labels
+
+			if err := h.kubernetesClient.Update(ctx, updatedConfigMap); err != nil {
+				return fmt.Errorf("error while updating configmap %s: %w", desiredConfigMap.Name, err)
+			}
+		}
+	}
+
+	// Delete the ConfigMaps that are not present in the desired state
+	for name, existingConfigMap := range currentMap {
+		if _, found := desiredMap[name]; !found {
+			if err := h.kubernetesClient.Delete(ctx, existingConfigMap); err != nil {
+				return fmt.Errorf("error while deleting configmap %s: %w", existingConfigMap.Name, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (h *configMapHandler) Delete(ctx context.Context, deployCtx *dataplane.DeploymentContext) error {
+	namespace := makeNamespaceName(deployCtx)
+	labels := makeWorkloadLabels(deployCtx)
+	deleteAllOpt := []client.DeleteAllOfOption{
+		// Make sure the correct labels are used, otherwise, it might delete unwanted ConfigMaps
+		client.InNamespace(namespace),
+		client.MatchingLabels(labels),
+	}
+	err := h.kubernetesClient.DeleteAllOf(ctx, &corev1.ConfigMap{}, deleteAllOpt...)
+	if err != nil {
+		return fmt.Errorf("error while deleting configmaps: %w", err)
+	}
+	return nil
+}
+
+func makeConfigMaps(deployCtx *dataplane.DeploymentContext) []*corev1.ConfigMap {
+	configMaps := make([]*corev1.ConfigMap, 0)
+	for _, cg := range deployCtx.ConfigurationGroups {
+		cgConfigs := cg.Spec.Configurations
+		if len(cgConfigs) == 0 {
+			continue
+		}
+
+		cm := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      makeConfigMapName(deployCtx, cg),
+				Namespace: makeNamespaceName(deployCtx),
+				Labels:    makeWorkloadLabels(deployCtx),
+			},
+		}
+		cmData := make(map[string]string)
+		for _, cgConfig := range cgConfigs {
+			cgv := findConfigGroupValueForEnv(cgConfig.Values, cg.Spec.EnvironmentGroups, deployCtx.Environment)
+			if cgv == nil || cgv.Value == "" {
+				continue
+			}
+			// TODO: Improvement: filter the values that are only used in deployable artifact
+			cmData[cgConfig.Key] = cgv.Value
+		}
+		cm.Data = cmData
+		configMaps = append(configMaps, cm)
+	}
+	return configMaps
+}
+
+func makeConfigMapName(deployCtx *dataplane.DeploymentContext, cg *choreov1.ConfigurationGroup) string {
+	// TODO: Ideally, this should be choreo name instead of kubernetes name
+	componentName := deployCtx.Component.Name
+	deploymentTrackName := deployCtx.DeploymentTrack.Name
+	configGroupName := cg.Name
+	// Limit the name to 253 characters to comply with the K8s name length limit for ConfigMaps
+	return dpkubernetes.GenerateK8sName(componentName, deploymentTrackName, configGroupName)
+}

--- a/internal/controller/deployment/integrations/kubernetes/configmap_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/configmap_handler_test.go
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+var _ = Describe("makeConfigMaps", func() {
+	var (
+		deployCtx  *dataplane.DeploymentContext
+		configMaps []*corev1.ConfigMap
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		configMaps = makeConfigMaps(deployCtx)
+	})
+
+	Context("for two Configuration Groups", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+			deployCtx.ConfigurationGroups = []*choreov1.ConfigurationGroup{
+				newTestRedisConfigurationGroup(),
+				newTestMysqlConfigurationGroup(),
+			}
+		})
+
+		It("should create two ConfigMaps with correct name and namespace", func() {
+			By("checking the generated ConfigMaps count")
+			Expect(configMaps).To(HaveLen(2))
+
+			By("checking the ConfigMap 1 names and namespaces")
+			Expect(configMaps[0].Name).To(Equal("my-component-my-main-track-redis-config-group-b8ef9df9"))
+			Expect(configMaps[0].Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
+
+			By("checking the ConfigMap 2 names and namespaces")
+			Expect(configMaps[1].Name).To(Equal("my-component-my-main-track-mysql-config-group-e7d2f2be"))
+			Expect(configMaps[1].Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
+		})
+
+		expectedLabels := map[string]string{
+			"organization-name":     "test-organization",
+			"project-name":          "my-project",
+			"environment-name":      "test-environment",
+			"component-name":        "my-component",
+			"component-type":        "Service",
+			"deployment-track-name": "my-main-track",
+			"deployment-name":       "my-deployment",
+			"managed-by":            "choreo-deployment-controller",
+			"belong-to":             "user-workloads",
+		}
+
+		It("should create ConfigMaps with valid labels", func() {
+			Expect(configMaps[0].Labels).To(BeComparableTo(expectedLabels))
+		})
+
+		It("should create the ConfigMap 1 with correct data", func() {
+			data := configMaps[0].Data
+			Expect(data).To(BeComparableTo(map[string]string{
+				"host": "redis-dev.test.com",
+				"port": "6379",
+			}))
+		})
+
+		It("should create the ConfigMap 2 with correct data", func() {
+			data := configMaps[1].Data
+			Expect(data).To(BeComparableTo(map[string]string{
+				"host": "mysql-dev.test.com",
+				"port": "3306",
+			}))
+		})
+	})
+
+	Context("for a Configuration Group with Environment Group", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+			deployCtx.ConfigurationGroups = []*choreov1.ConfigurationGroup{
+				newTestConfigurationGroup("salesforce-config-group",
+					choreov1.ConfigurationGroupSpec{
+						EnvironmentGroups: []choreov1.EnvironmentGroup{
+							{
+								Name:         "non-prod",
+								Environments: []string{"test-environment"},
+							},
+						},
+						Configurations: []choreov1.ConfigurationGroupConfiguration{
+							{
+								Key: "host",
+								Values: []choreov1.ConfigurationValue{
+									{
+										EnvironmentGroupRef: "non-prod",
+										Value:               "sandbox.salesforce.com",
+									},
+								},
+							},
+						},
+					},
+				),
+			}
+		})
+
+		It("should create a ConfigMap with correct data", func() {
+			data := configMaps[0].Data
+			Expect(data).To(BeComparableTo(map[string]string{
+				"host": "sandbox.salesforce.com",
+			}))
+		})
+	})
+
+})

--- a/internal/controller/deployment/integrations/kubernetes/cronjob_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/cronjob_handler_test.go
@@ -51,13 +51,13 @@ var _ = Describe("makeCronJob", func() {
 		It("should create a CronJob with correct name and namespace", func() {
 			Expect(cronJob).NotTo(BeNil())
 			Expect(cronJob.Name).To(Equal("my-component-my-main-track-a43a18e7"))
-			Expect(cronJob.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+			Expect(cronJob.Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
 		})
 
 		expectedLabels := map[string]string{
 			"organization-name":     "test-organization",
 			"project-name":          "my-project",
-			"environment-name":      "development",
+			"environment-name":      "test-environment",
 			"component-name":        "my-component",
 			"component-type":        "ScheduledTask",
 			"deployment-track-name": "my-main-track",

--- a/internal/controller/deployment/integrations/kubernetes/deployment_handler.go
+++ b/internal/controller/deployment/integrations/kubernetes/deployment_handler.go
@@ -140,16 +140,6 @@ func makeDeployment(deployCtx *dataplane.DeploymentContext) *appsv1.Deployment {
 }
 
 func makeDeploymentSpec(deployCtx *dataplane.DeploymentContext) appsv1.DeploymentSpec {
-	mainContainer := corev1.Container{
-		Name:  "main",
-		Image: deployCtx.ContainerImage,
-	}
-
-	artifactConfig := deployCtx.DeployableArtifact.Spec.Configuration
-	if artifactConfig != nil {
-		mainContainer.Ports = makeContainerPortsFromEndpointTemplates(artifactConfig.EndpointTemplates)
-	}
-
 	deploymentSpec := appsv1.DeploymentSpec{
 		Selector: &metav1.LabelSelector{
 			MatchLabels: makeWorkloadLabels(deployCtx),
@@ -158,11 +148,7 @@ func makeDeploymentSpec(deployCtx *dataplane.DeploymentContext) appsv1.Deploymen
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: makeWorkloadLabels(deployCtx),
 			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					mainContainer,
-				},
-			},
+			Spec: *makePodSpec(deployCtx),
 		},
 	}
 

--- a/internal/controller/deployment/integrations/kubernetes/deployment_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/deployment_handler_test.go
@@ -52,13 +52,13 @@ var _ = Describe("makeDeployment", func() {
 		It("should create a Deployment with correct name and namespace", func() {
 			Expect(deployment).NotTo(BeNil())
 			Expect(deployment.Name).To(Equal("my-component-my-main-track-a43a18e7"))
-			Expect(deployment.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+			Expect(deployment.Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
 		})
 
 		expectedLabels := map[string]string{
 			"organization-name":     "test-organization",
 			"project-name":          "my-project",
-			"environment-name":      "development",
+			"environment-name":      "test-environment",
 			"component-name":        "my-component",
 			"component-type":        "Service",
 			"deployment-track-name": "my-main-track",

--- a/internal/controller/deployment/integrations/kubernetes/namespace_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/namespace_handler_test.go
@@ -45,13 +45,13 @@ var _ = Describe("makeNamespace", func() {
 
 		It("should create a Namespace with valid name", func() {
 			Expect(namespace).NotTo(BeNil())
-			Expect(namespace.Name).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+			Expect(namespace.Name).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
 		})
 
 		expectedLabels := map[string]string{
 			"organization-name": "test-organization",
 			"project-name":      "my-project",
-			"environment-name":  "development",
+			"environment-name":  "test-environment",
 			"managed-by":        "choreo-deployment-controller",
 			"belong-to":         "user-workloads",
 		}

--- a/internal/controller/deployment/integrations/kubernetes/pod.go
+++ b/internal/controller/deployment/integrations/kubernetes/pod.go
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+func makePodSpec(deployCtx *dataplane.DeploymentContext) *corev1.PodSpec {
+	ps := &corev1.PodSpec{}
+	ps.Containers = []corev1.Container{*makeMainContainer(deployCtx)}
+	ps.RestartPolicy = getRestartPolicy(deployCtx)
+	return ps
+}
+
+func makeMainContainer(deployCtx *dataplane.DeploymentContext) *corev1.Container {
+	c := &corev1.Container{
+		Name:  "main",
+		Image: deployCtx.ContainerImage,
+	}
+
+	c.Env = makeEnvironmentVariables(deployCtx)
+
+	artifactConfig := deployCtx.DeployableArtifact.Spec.Configuration
+	if artifactConfig != nil {
+		c.Ports = makeContainerPortsFromEndpointTemplates(artifactConfig.EndpointTemplates)
+	}
+
+	return c
+}
+
+func makeEnvironmentVariables(deployCtx *dataplane.DeploymentContext) []corev1.EnvVar {
+	if deployCtx.DeployableArtifact.Spec.Configuration == nil ||
+		deployCtx.DeployableArtifact.Spec.Configuration.Application == nil {
+		return nil
+	}
+
+	var k8sEnvVars []corev1.EnvVar
+
+	// Build the container environment variables from the direct values and configuration groups mapping.
+	// Example Direct values:
+	// env:
+	//   - key: REDIS_HOST
+	//	   value: redis.example.com
+	// Example Configuration group mapping:
+	// env:
+	//   - key: REDIS_HOST
+	//	   valueFrom:
+	//	     configurationGroupRef:
+	//		   name: redis-config
+	//		   key: redis-host
+	envVars := deployCtx.DeployableArtifact.Spec.Configuration.Application.Env
+	for _, envVar := range envVars {
+		if envVar.Key == "" {
+			continue
+		}
+		// Direct values set in the deployable artifact configuration
+		if envVar.Value != "" {
+			k8sEnvVars = append(k8sEnvVars, corev1.EnvVar{
+				Name:  envVar.Key,
+				Value: envVar.Value,
+			})
+			continue
+		}
+		// Values set from a configuration group
+		if envVar.ValueFrom != nil && envVar.ValueFrom.ConfigurationGroupRef != nil {
+			cgRef := envVar.ValueFrom.ConfigurationGroupRef
+			targetCg := findConfigGroupByName(deployCtx.ConfigurationGroups, cgRef.Name)
+			if targetCg == nil {
+				continue // Ignore if the configuration group is not found.
+			}
+			configMapName := makeConfigMapName(deployCtx, targetCg)
+			k8sEnvVars = append(k8sEnvVars, corev1.EnvVar{
+				Name: envVar.Key,
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Key: cgRef.Key,
+					},
+				},
+			})
+		}
+	}
+
+	// Build the container environment variables from the bulk configuration group injection.
+	// Example Configuration group injection:
+	// envFrom:
+	//   - configurationGroupRef:
+	//       name: redis-config
+	envFromSources := deployCtx.DeployableArtifact.Spec.Configuration.Application.EnvFrom
+	for _, envFrom := range envFromSources {
+		if envFrom.ConfigurationGroupRef == nil {
+			continue
+		}
+		cgRef := envFrom.ConfigurationGroupRef
+		targetCg := findConfigGroupByName(deployCtx.ConfigurationGroups, cgRef.Name)
+		if targetCg == nil {
+			continue // Ignore if the configuration group is not found.
+		}
+		configMapName := makeConfigMapName(deployCtx, targetCg)
+
+		for _, cfConfig := range targetCg.Spec.Configurations {
+			envKey := sanitizeEnvVarKey(cfConfig.Key)
+			if envKey == "" {
+				continue
+			}
+			k8sEnvVars = append(k8sEnvVars, corev1.EnvVar{
+				Name: envKey,
+				ValueFrom: &corev1.EnvVarSource{
+					ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: configMapName,
+						},
+						Key: cfConfig.Key,
+					},
+				},
+			})
+		}
+	}
+
+	return k8sEnvVars
+}
+
+func getRestartPolicy(deployCtx *dataplane.DeploymentContext) corev1.RestartPolicy {
+	if deployCtx.Component.Spec.Type == choreov1.ComponentTypeScheduledTask ||
+		deployCtx.Component.Spec.Type == choreov1.ComponentTypeManualTask {
+		return corev1.RestartPolicyNever
+	}
+	return corev1.RestartPolicyAlways
+}

--- a/internal/controller/deployment/integrations/kubernetes/pod_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/pod_test.go
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/dataplane"
+)
+
+var _ = Describe("makePodSpec", func() {
+	var (
+		deployCtx *dataplane.DeploymentContext
+		podSpec   *corev1.PodSpec
+	)
+
+	// Prepare fresh DeploymentContext before each test
+	BeforeEach(func() {
+		deployCtx = newTestDeploymentContext()
+	})
+
+	JustBeforeEach(func() {
+		podSpec = makePodSpec(deployCtx)
+	})
+
+	Context("for a Service component", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeService
+		})
+
+		It("should create a PodSpec with correct RestartPolicy", func() {
+			Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyAlways))
+		})
+	})
+
+	Context("for a Scheduled Task component", func() {
+		BeforeEach(func() {
+			deployCtx.Component.Spec.Type = choreov1.ComponentTypeScheduledTask
+		})
+
+		It("should create a PodSpec with correct RestartPolicy", func() {
+			Expect(podSpec.RestartPolicy).To(Equal(corev1.RestartPolicyNever))
+		})
+	})
+
+	Context("when the deployable artifact has direct environment variables", func() {
+		BeforeEach(func() {
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				Application: &choreov1.Application{
+					Env: []choreov1.EnvVar{
+						{
+							Key:   "LOG_FORMAT",
+							Value: "json",
+						},
+					},
+				},
+			}
+		})
+
+		It("should create a PodSpec with correct environment variables", func() {
+			Expect(podSpec.Containers).To(HaveLen(1))
+			Expect(podSpec.Containers[0].Env).To(ConsistOf(
+				corev1.EnvVar{
+					Name:  "LOG_FORMAT",
+					Value: "json",
+				},
+			))
+		})
+	})
+
+	Context("when the deployable artifact has environment variables mapped from configuration groups", func() {
+		BeforeEach(func() {
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				Application: &choreov1.Application{
+					Env: []choreov1.EnvVar{
+						{
+							Key: "REDIS_HOST",
+							ValueFrom: &choreov1.EnvVarValueFrom{
+								ConfigurationGroupRef: &choreov1.ConfigurationGroupKeyRef{
+									Name: "redis-config-group",
+									Key:  "host",
+								},
+							},
+						},
+						{
+							Key: "REDIS_PORT",
+							ValueFrom: &choreov1.EnvVarValueFrom{
+								ConfigurationGroupRef: &choreov1.ConfigurationGroupKeyRef{
+									Name: "redis-config-group",
+									Key:  "port",
+								},
+							},
+						},
+						{
+							Key: "MYSQL_HOST",
+							ValueFrom: &choreov1.EnvVarValueFrom{
+								ConfigurationGroupRef: &choreov1.ConfigurationGroupKeyRef{
+									Name: "mysql-config-group",
+									Key:  "host",
+								},
+							},
+						},
+						{
+							Key: "MYSQL_PORT",
+							ValueFrom: &choreov1.EnvVarValueFrom{
+								ConfigurationGroupRef: &choreov1.ConfigurationGroupKeyRef{
+									Name: "mysql-config-group",
+									Key:  "port",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			deployCtx.ConfigurationGroups = []*choreov1.ConfigurationGroup{
+				newTestRedisConfigurationGroup(),
+				newTestMysqlConfigurationGroup(),
+			}
+		})
+
+		It("should create a PodSpec with correct environment variables", func() {
+			Expect(podSpec.Containers).To(HaveLen(1))
+
+			envs := podSpec.Containers[0].Env
+			By("checking the environment variables count")
+			Expect(envs).To(HaveLen(4))
+
+			By("checking the REDIS_HOST environment variable")
+			Expect(envs[0].Name).To(Equal("REDIS_HOST"))
+			Expect(envs[0].ValueFrom).To(BeComparableTo(&corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "my-component-my-main-track-redis-config-group-b8ef9df9",
+					},
+					Key: "host",
+				},
+			}))
+
+			By("checking the MYSQL_PORT environment variable")
+			Expect(envs[3].Name).To(Equal("MYSQL_PORT"))
+			Expect(envs[3].ValueFrom).To(BeComparableTo(&corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "my-component-my-main-track-mysql-config-group-e7d2f2be",
+					},
+					Key: "port",
+				},
+			}))
+		})
+	})
+
+	// Bulk mapping means that the entire configuration group is mapped to the environment variables
+	// without specifying the individual keys. The generator must sanitize the keys.
+	// Example Configuration group injection:
+	// envFrom:
+	//   - configurationGroupRef:
+	//       name: redis-config
+	Context("when the deployable artifact has environment variables bulk mapping a configuration group", func() {
+		BeforeEach(func() {
+			deployCtx.DeployableArtifact.Spec.Configuration = &choreov1.Configuration{
+				Application: &choreov1.Application{
+					EnvFrom: []choreov1.EnvFromSource{
+						{
+							ConfigurationGroupRef: &choreov1.ConfigurationGroupRef{
+								Name: "redis-config-group",
+							},
+						},
+					},
+				},
+			}
+
+			deployCtx.ConfigurationGroups = []*choreov1.ConfigurationGroup{
+				newTestRedisConfigurationGroup(),
+				newTestMysqlConfigurationGroup(),
+			}
+		})
+
+		It("should create a PodSpec with correct environment variables", func() {
+			Expect(podSpec.Containers).To(HaveLen(1))
+
+			envs := podSpec.Containers[0].Env
+			By("checking the environment variables count")
+			Expect(envs).To(HaveLen(2))
+
+			By("checking the sanitized 'host' environment variable")
+			Expect(envs[0].Name).To(Equal("HOST"))
+			Expect(envs[0].ValueFrom).To(BeComparableTo(&corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "my-component-my-main-track-redis-config-group-b8ef9df9",
+					},
+					Key: "host",
+				},
+			}))
+
+			By("checking the `port` environment variable")
+			Expect(envs[1].Name).To(Equal("PORT"))
+			Expect(envs[1].ValueFrom).To(BeComparableTo(&corev1.EnvVarSource{
+				ConfigMapKeyRef: &corev1.ConfigMapKeySelector{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "my-component-my-main-track-redis-config-group-b8ef9df9",
+					},
+					Key: "port",
+				},
+			}))
+		})
+	})
+})

--- a/internal/controller/deployment/integrations/kubernetes/service_handler_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/service_handler_test.go
@@ -71,13 +71,13 @@ var _ = Describe("makeService", func() {
 		It("should create a Service with correct name and namespace", func() {
 			Expect(service).NotTo(BeNil())
 			Expect(service.Name).To(Equal("my-component-my-main-track-a43a18e7"))
-			Expect(service.Namespace).To(Equal("dp-test-organiza-my-project-development-314a8e4f"))
+			Expect(service.Namespace).To(Equal("dp-test-organiza-my-project-test-environ-04bdf416"))
 		})
 
 		expectedLabels := map[string]string{
 			"organization-name":     "test-organization",
 			"project-name":          "my-project",
-			"environment-name":      "development",
+			"environment-name":      "test-environment",
 			"component-name":        "my-component",
 			"component-type":        "Service",
 			"deployment-track-name": "my-main-track",

--- a/internal/controller/deployment/integrations/kubernetes/suite_test.go
+++ b/internal/controller/deployment/integrations/kubernetes/suite_test.go
@@ -52,18 +52,18 @@ func newTestDeploymentContext() *dataplane.DeploymentContext {
 	}
 	deployCtx.Environment = &choreov1.Environment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "development",
-			Namespace: "test-namespace",
+			Name:      "test-environment",
+			Namespace: "test-organization",
 			Labels: map[string]string{
 				labels.LabelKeyOrganizationName: "test-organization",
-				labels.LabelKeyName:             "development",
+				labels.LabelKeyName:             "test-environment",
 			},
 		},
 	}
 	deployCtx.Component = &choreov1.Component{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-component",
-			Namespace: "test-namespace",
+			Namespace: "test-organization",
 			Labels: map[string]string{
 				labels.LabelKeyOrganizationName: "test-organization",
 				labels.LabelKeyProjectName:      "my-project",
@@ -74,7 +74,7 @@ func newTestDeploymentContext() *dataplane.DeploymentContext {
 	deployCtx.DeploymentTrack = &choreov1.DeploymentTrack{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-main-track",
-			Namespace: "test-namespace",
+			Namespace: "test-organization",
 			Labels: map[string]string{
 				labels.LabelKeyOrganizationName: "test-organization",
 				labels.LabelKeyProjectName:      "my-project",
@@ -86,7 +86,7 @@ func newTestDeploymentContext() *dataplane.DeploymentContext {
 	deployCtx.DeployableArtifact = &choreov1.DeployableArtifact{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-artifact",
-			Namespace: "test-namespace",
+			Namespace: "test-organization",
 			Labels: map[string]string{
 				labels.LabelKeyOrganizationName:    "test-organization",
 				labels.LabelKeyProjectName:         "my-project",
@@ -100,11 +100,11 @@ func newTestDeploymentContext() *dataplane.DeploymentContext {
 	deployCtx.Deployment = &choreov1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-deployment",
-			Namespace: "test-namespace",
+			Namespace: "test-organization",
 			Labels: map[string]string{
 				labels.LabelKeyOrganizationName:    "test-organization",
 				labels.LabelKeyProjectName:         "my-project",
-				labels.LabelKeyEnvironmentName:     "my-environment",
+				labels.LabelKeyEnvironmentName:     "test-environment",
 				labels.LabelKeyComponentName:       "my-component",
 				labels.LabelKeyDeploymentTrackName: "my-main-track",
 				labels.LabelKeyName:                "my-deployment",
@@ -115,4 +115,88 @@ func newTestDeploymentContext() *dataplane.DeploymentContext {
 	deployCtx.ContainerImage = "my-image:latest"
 
 	return deployCtx
+}
+
+func newTestConfigurationGroup(name string, spec choreov1.ConfigurationGroupSpec) *choreov1.ConfigurationGroup {
+	return &choreov1.ConfigurationGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "test-organization",
+			Labels: map[string]string{
+				labels.LabelKeyOrganizationName: "test-organization",
+				labels.LabelKeyName:             name,
+			},
+		},
+		Spec: spec,
+	}
+}
+
+func newTestRedisConfigurationGroup() *choreov1.ConfigurationGroup {
+	return newTestConfigurationGroup(
+		"redis-config-group",
+		choreov1.ConfigurationGroupSpec{
+			Configurations: []choreov1.ConfigurationGroupConfiguration{
+				{
+					Key: "host",
+					Values: []choreov1.ConfigurationValue{
+						{
+							Environment: "test-environment",
+							Value:       "redis-dev.test.com",
+						},
+						{
+							Environment: "production",
+							Value:       "redis.test.com",
+						},
+					},
+				},
+				{
+					Key: "port",
+					Values: []choreov1.ConfigurationValue{
+						{
+							Environment: "test-environment",
+							Value:       "6379",
+						},
+						{
+							Environment: "production",
+							Value:       "6380",
+						},
+					},
+				},
+			},
+		})
+}
+
+func newTestMysqlConfigurationGroup() *choreov1.ConfigurationGroup {
+	return newTestConfigurationGroup(
+		"mysql-config-group",
+		choreov1.ConfigurationGroupSpec{
+			Configurations: []choreov1.ConfigurationGroupConfiguration{
+				{
+					Key: "host",
+					Values: []choreov1.ConfigurationValue{
+						{
+							Environment: "test-environment",
+							Value:       "mysql-dev.test.com",
+						},
+						{
+							Environment: "production",
+							Value:       "mysql.test.com",
+						},
+					},
+				},
+				{
+					Key: "port",
+					Values: []choreov1.ConfigurationValue{
+						{
+							Environment: "test-environment",
+							Value:       "3306",
+						},
+						{
+							Environment: "production",
+							Value:       "3306",
+						},
+					},
+				},
+			},
+		})
 }

--- a/internal/dataplane/types.go
+++ b/internal/dataplane/types.go
@@ -33,6 +33,8 @@ type DeploymentContext struct {
 	Deployment         *choreov1.Deployment
 	Environment        *choreov1.Environment
 
+	ConfigurationGroups []*choreov1.ConfigurationGroup
+
 	ContainerImage string
 }
 


### PR DESCRIPTION
## Purpose
Add the plain-text environment variable injection via the config groups

## Approach
This PR introduces the user workload configuration with environment variables (only plain-text values) using the configuration groups. The following changes are implemented,

- Inject the environment variables (keys and values) that are directly specified in the deployable artifact
- Inject the environment variables (keys and values) that are mapped to a configuration group.
  ```yaml
  env:
  - key: REDIS_HOST
     valueFrom:
       configurationGroupRef:
         name: redis-config
         key: redis-host
  ```
- Inject bulk environment variables (keys and values) directly from the configuration group
  ```yaml
  envFrom:
  - configurationGroupRef:
      name: redis-config
  ```
- Support for using environment groups inside the configuration group

 
## Related Issues
- https://github.com/choreo-idp/choreo/issues/28

## Checklist
- [x] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
A sample will be added in a separate PR to demonstrate the usage of configuration groups.
