### PR TITLE
Add delete -f resource.yaml functionality in Choreo CLI

### DIFF
--- a/internal/choreoctl/cmd/apply/apply.go
+++ b/internal/choreoctl/cmd/apply/apply.go
@@ -23,8 +23,7 @@ import (
 	"os"
 	"os/exec"
 
-	"github.com/spf13/viper"
-
+	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/config"
 	"github.com/choreo-idp/choreo/pkg/cli/types/api"
 )
 
@@ -50,9 +49,10 @@ func (i *ApplyImpl) Apply(params api.ApplyParams) error {
 		return fmt.Errorf("error reading file: %s", params.FilePath)
 	}
 
-	// Get saved kubeconfig and context
-	kubeconfig := viper.GetString("kubeconfig")
-	context := viper.GetString("context")
+	kubeconfig, context, err := config.GetStoredKubeConfigValues()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig values: %w", err)
+	}
 
 	// Execute kubectl apply ToDo: move to use k8s client instead of kubectl
 	cmd := exec.Command("kubectl",

--- a/internal/choreoctl/cmd/delete/delete.go
+++ b/internal/choreoctl/cmd/delete/delete.go
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+// Package delete provides functionality to delete Choreo resources
+package delete
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+
+	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/config"
+	"github.com/choreo-idp/choreo/pkg/cli/types/api"
+)
+
+// DeleteImpl implements the delete command for Choreo resources
+type DeleteImpl struct{}
+
+// Resource dependency order from leaf to root based on the Choreo resource relationships
+var resourceDeleteOrder = []string{
+	"endpoint",           // Most leaf-level resource
+	"deploymentrevision", // Should be deleted before its parent deployment
+	"deployment",         // Should be deleted before deploymenttrack
+	"deployableartifact", // Should be deleted after deployment but before build
+	"build",              // Should be deleted after deployableartifact but before component
+	"deploymenttrack",    // Should be deleted after deployment but before component
+	"configurationgroup", // Referenced by deployableartifact
+	"component",          // Should be deleted after its child resources
+	"environment",        // Should be deleted after deployment
+	"deploymentpipeline", // Should be deleted after environments
+	"dataplane",          // Should be deleted after environments
+	"project",            // Should be deleted after all components
+	"organization",       // Root level resource, deleted last
+}
+
+// NewDeleteImpl creates a new instance of DeleteImpl
+func NewDeleteImpl() *DeleteImpl {
+	return &DeleteImpl{}
+}
+
+// Delete removes resources specified in the given file
+func (i *DeleteImpl) Delete(params api.DeleteParams) error {
+	if params.FilePath == "" {
+		return fmt.Errorf("file path is required")
+	}
+
+	if _, err := os.Stat(params.FilePath); os.IsNotExist(err) {
+		return fmt.Errorf("file %s does not exist", params.FilePath)
+	}
+
+	fileBytes, err := os.ReadFile(params.FilePath)
+	if err != nil {
+		if os.IsPermission(err) {
+			return fmt.Errorf("permission denied: %s", params.FilePath)
+		}
+		return fmt.Errorf("error reading file: %s", params.FilePath)
+	}
+
+	kubeconfig, context, err := config.GetStoredKubeConfigValues()
+	if err != nil {
+		return fmt.Errorf("failed to get kubeconfig values: %w", err)
+	}
+
+	if isMultiDocYAML(fileBytes) {
+		return deleteResourcesInOrder(fileBytes, kubeconfig, context, params.Wait)
+	}
+
+	deleteArgs := []string{"delete", "-f", params.FilePath}
+	if params.Wait {
+		deleteArgs = append(deleteArgs, "--wait")
+	}
+
+	err = executeKubectl(kubeconfig, context, deleteArgs, fmt.Sprintf("Deleting resources from %s", params.FilePath))
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Resources deleted successfully from %s\n", params.FilePath)
+	return nil
+}
+
+// executeKubectl executes kubectl command with the given arguments
+func executeKubectl(kubeconfig, context string, args []string, description string) error {
+	kubectlArgs := []string{
+		"--kubeconfig", kubeconfig,
+		"--context", context,
+	}
+	kubectlArgs = append(kubectlArgs, args...)
+
+	cmd := exec.Command("kubectl", kubectlArgs...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	fmt.Printf("%s...\n", description)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to execute kubectl command: %w", err)
+	}
+	return nil
+}
+
+// isMultiDocYAML checks if the file contains multiple YAML documents
+func isMultiDocYAML(content []byte) bool {
+	return bytes.Count(content, []byte("---")) > 0
+}
+
+// deleteResourcesInOrder processes multiple resources and deletes them in dependency order
+func deleteResourcesInOrder(fileBytes []byte, kubeconfig, context string, wait bool) error {
+	resources, err := parseResources(fileBytes)
+	if err != nil {
+		return fmt.Errorf("error parsing resources: %w", err)
+	}
+
+	if len(resources) == 0 {
+		return fmt.Errorf("no valid resources found in the file")
+	}
+
+	resourcesByKind := groupResourcesByKind(resources)
+
+	tempDir, err := os.MkdirTemp("", "choreo-delete")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	processedKinds := make(map[string]bool)
+
+	// Process resources according to defined order first
+	for _, kind := range resourceDeleteOrder {
+		lowercaseKind := strings.ToLower(kind)
+		resourcesToDelete, exists := resourcesByKind[lowercaseKind]
+		if !exists {
+			continue
+		}
+
+		fmt.Printf("Deleting %s resources...\n", kind)
+		if err := deleteResourcesOfKind(resourcesToDelete, tempDir, kubeconfig, context, wait); err != nil {
+			return err
+		}
+
+		processedKinds[lowercaseKind] = true
+	}
+
+	// Process any remaining unordered kinds
+	for kind, resourcesToDelete := range resourcesByKind {
+		if processedKinds[kind] {
+			continue
+		}
+
+		fmt.Printf("Deleting %s resources (unordered)...\n", kind)
+		if err := deleteResourcesOfKind(resourcesToDelete, tempDir, kubeconfig, context, wait); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// deleteResourcesOfKind deletes all resources of a specific kind
+func deleteResourcesOfKind(resources []*unstructured.Unstructured, tempDir, kubeconfig, context string, wait bool) error {
+	for _, resource := range resources {
+		tempFile := fmt.Sprintf("%s/%s-%s.yaml", tempDir, strings.ToLower(resource.GetKind()), resource.GetName())
+		resourceYAML, err := unstructuredToYAML(resource)
+		if err != nil {
+			return fmt.Errorf("failed to convert resource to YAML for %s/%s: %w", resource.GetKind(), resource.GetName(), err)
+		}
+
+		if err := os.WriteFile(tempFile, []byte(resourceYAML), 0600); err != nil {
+			return fmt.Errorf("failed to write temporary file for %s/%s: %w", resource.GetKind(), resource.GetName(), err)
+		}
+
+		deleteArgs := []string{"delete", "-f", tempFile}
+		if wait {
+			deleteArgs = append(deleteArgs, "--wait")
+		}
+
+		description := fmt.Sprintf("Deleting %s/%s", resource.GetKind(), resource.GetName())
+		if err := executeKubectl(kubeconfig, context, deleteArgs, description); err != nil {
+			return fmt.Errorf("failed to delete %s/%s: %w", resource.GetKind(), resource.GetName(), err)
+		}
+
+		fmt.Printf("Deleted %s/%s\n", resource.GetKind(), resource.GetName())
+	}
+	return nil
+}
+
+// parseResources parses the YAML file into a list of unstructured resources
+func parseResources(fileBytes []byte) ([]*unstructured.Unstructured, error) {
+	var resources []*unstructured.Unstructured
+	decoder := yaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	reader := bufio.NewReader(bytes.NewReader(fileBytes))
+
+	var buffer bytes.Buffer
+	for {
+		line, err := reader.ReadString('\n')
+		if err != nil && err != io.EOF {
+			return nil, err
+		}
+
+		if strings.HasPrefix(line, "---") || err == io.EOF {
+			if buffer.Len() > 0 {
+				content := strings.TrimSpace(buffer.String())
+				if content != "" {
+					obj := &unstructured.Unstructured{}
+					if _, _, err := decoder.Decode([]byte(content), nil, obj); err == nil {
+						if obj.GetKind() != "" {
+							resources = append(resources, obj)
+						}
+					}
+				}
+				buffer.Reset()
+			}
+
+			if err == io.EOF {
+				break
+			}
+			continue
+		}
+
+		buffer.WriteString(line)
+	}
+
+	return resources, nil
+}
+
+// groupResourcesByKind groups resources by their lowercase kind
+func groupResourcesByKind(resources []*unstructured.Unstructured) map[string][]*unstructured.Unstructured {
+	result := make(map[string][]*unstructured.Unstructured)
+	for _, res := range resources {
+		kind := strings.ToLower(res.GetKind())
+		result[kind] = append(result[kind], res)
+	}
+	return result
+}
+
+// unstructuredToYAML converts an unstructured resource back to YAML
+func unstructuredToYAML(obj *unstructured.Unstructured) (string, error) {
+	jsonBytes, err := obj.MarshalJSON()
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal resource to JSON: %w", err)
+	}
+
+	cmd := exec.Command("kubectl", "get", "-f", "-", "-o", "yaml")
+	cmd.Stdin = bytes.NewReader(jsonBytes)
+	yamlBytes, err := cmd.Output()
+	if err != nil {
+		var stderr []byte
+		// Use errors.As instead of type assertion (addressing errorlint)
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderr = exitErr.Stderr
+		}
+		return "", fmt.Errorf("failed to convert resource to YAML: %w\n%s", err, stderr)
+	}
+
+	return string(yamlBytes), nil
+}

--- a/internal/choreoctl/impl.go
+++ b/internal/choreoctl/impl.go
@@ -30,6 +30,7 @@ import (
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/environment"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/organization"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/project"
+	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/delete"
 	getbuild "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/build"
 	getcomponent "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/component"
 	getdataplane "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/dataplane"
@@ -152,6 +153,13 @@ func (c *CommandImplementation) CreateDeploymentTrack(params api.CreateDeploymen
 func (c *CommandImplementation) CreateDeployableArtifact(params api.CreateDeployableArtifactParams) error {
 	daImpl := deployableartifact.NewCreateDeployableArtifactImpl(constants.DeployableArtifactV1Config)
 	return daImpl.CreateDeployableArtifact(params)
+}
+
+// Delete Operations
+
+func (c *CommandImplementation) Delete(params api.DeleteParams) error {
+	deleteImpl := delete.NewDeleteImpl()
+	return deleteImpl.Delete(params)
 }
 
 // Authentication Operations

--- a/pkg/cli/cmd/delete/delete.go
+++ b/pkg/cli/cmd/delete/delete.go
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package delete
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/choreo-idp/choreo/pkg/cli/common/constants"
+	"github.com/choreo-idp/choreo/pkg/cli/flags"
+	"github.com/choreo-idp/choreo/pkg/cli/types/api"
+)
+
+// NewDeleteCmd creates the main delete command
+func NewDeleteCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:     constants.Delete.Use,
+		Short:   constants.Delete.Short,
+		Long:    constants.Delete.Long,
+		Example: constants.Delete.Example,
+	}
+
+	// Add the file and wait flags directly to deleteCmd
+	deleteCmd.Flags().StringP(flags.DeleteFileFlag.Name, flags.DeleteFileFlag.Shorthand, "", flags.DeleteFileFlag.Usage)
+	deleteCmd.Flags().BoolP(flags.Wait.Name, flags.Wait.Shorthand, false, flags.Wait.Usage)
+
+	// Add a special handler for -f/--file flag
+	deleteCmd.RunE = func(cmd *cobra.Command, args []string) error {
+		filePath, _ := cmd.Flags().GetString(flags.DeleteFileFlag.Name)
+		if filePath != "" {
+			wait, _ := cmd.Flags().GetBool(flags.Wait.Name)
+			return impl.Delete(api.DeleteParams{
+				FilePath: filePath,
+				Wait:     wait,
+			})
+		}
+		// Default behavior
+		return cmd.Help()
+	}
+
+	return deleteCmd
+}

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -520,4 +520,17 @@ If no organization is specified, you will be prompted to select one interactivel
 
 	// FlagDeployableArtifactDesc is used for the --deployableartifact flag.
 	FlagDeployableArtifactDesc = "Deployable artifact name stored in this context"
+
+	// ------------------------------------------------------------------------
+	// Delete Command Definitions
+	// ------------------------------------------------------------------------
+
+	// Delete command definitions
+	Delete = Command{
+		Use:   "delete",
+		Short: "Delete Choreo resources",
+		Long:  "Delete resources in Choreo platform such as organizations, projects, components, etc.",
+		Example: `  # Delete resources from a YAML file
+  choreoctl delete -f resources.yaml`,
+	}
 )

--- a/pkg/cli/common/messages/messages.go
+++ b/pkg/cli/common/messages/messages.go
@@ -78,6 +78,8 @@ const (
 	FlagEnvironmentDesc        = "Environment to deploy the component (e.g., dev, staging, prod)"
 	FlagDeployableArtifactDesc = "Deployable artifact name (e.g., my-artifact)"
 	FlagDeploymentDesc         = "Name of the deployment (e.g., my-deployment)"
+	DeleteFileFlag             = "Path to the configuration file to delete (e.g., deploy.yaml)"
+	FlagWaitDesc               = "Wait for resources to be deleted before returning"
 )
 
 type ApplyError struct {

--- a/pkg/cli/core/root/root.go
+++ b/pkg/cli/core/root/root.go
@@ -24,6 +24,7 @@ import (
 	"github.com/choreo-idp/choreo/pkg/cli/cmd/apply"
 	configContext "github.com/choreo-idp/choreo/pkg/cli/cmd/config"
 	"github.com/choreo-idp/choreo/pkg/cli/cmd/create"
+	"github.com/choreo-idp/choreo/pkg/cli/cmd/delete"
 	"github.com/choreo-idp/choreo/pkg/cli/cmd/get"
 	"github.com/choreo-idp/choreo/pkg/cli/cmd/logs"
 	"github.com/choreo-idp/choreo/pkg/cli/common/config"
@@ -47,6 +48,7 @@ func BuildRootCmd(config *config.CLIConfig, impl api.CommandImplementationInterf
 		// logout.NewLogoutCmd(impl),
 		logs.NewLogsCmd(impl),
 		configContext.NewConfigCmd(impl),
+		delete.NewDeleteCmd(impl),
 	)
 
 	return rootCmd

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -276,6 +276,19 @@ var (
 		Name:  "kube-context",
 		Usage: "Name of the kubeconfig context to use",
 	}
+
+	Wait = Flag{
+		Name:      "wait",
+		Shorthand: "w",
+		Usage:     messages.FlagWaitDesc,
+		Type:      "bool",
+	}
+
+	DeleteFileFlag = Flag{
+		Name:      "file",
+		Shorthand: "f",
+		Usage:     messages.DeleteFileFlag,
+	}
 )
 
 // AddFlags adds the specified flags to the given command.

--- a/pkg/cli/types/api/api.go
+++ b/pkg/cli/types/api/api.go
@@ -27,6 +27,7 @@ type CommandImplementationInterface interface {
 	DeployableArtifactAPI
 	DeploymentAPI
 	ApplyAPI
+	DeleteAPI
 	LoginAPI
 	LogoutAPI
 	LogAPI
@@ -74,6 +75,11 @@ type DeploymentAPI interface {
 // ApplyAPI defines methods for applying configurations
 type ApplyAPI interface {
 	Apply(params ApplyParams) error
+}
+
+// DeleteAPI defines methods for deleting resources from configuration files
+type DeleteAPI interface {
+	Delete(params DeleteParams) error
 }
 
 // LoginAPI defines methods for authentication

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -90,6 +90,11 @@ type ApplyParams struct {
 	FilePath string
 }
 
+type DeleteParams struct {
+	FilePath string
+	Wait     bool
+}
+
 // LoginParams defines parameters for login
 type LoginParams struct {
 	KubeconfigPath string


### PR DESCRIPTION
## Purpose
To support ```choreoctl delete -f resource.yaml``` functionality in Choreo CLI. 

## Approach
Read the provided resource yaml, order them for deletion based on the resource hierarchy defined as below, delete using kubectl delete -f sub-resource.yaml.  
```
var resourceDeleteOrder = []string{
	"endpoint",           // Most leaf-level resource
	"deploymentrevision", // Should be deleted before its parent deployment
	"deployment",         // Should be deleted before deploymenttrack
	"deployableartifact", // Should be deleted after deployment but before build
	"build",              // Should be deleted after deployableartifact but before component
	"deploymenttrack",    // Should be deleted after deployment but before component
	"configurationgroup", // Referenced by deployableartifact
	"component",          // Should be deleted after its child resources
	"environment",        // Should be deleted after deployment
	"deploymentpipeline", // Should be deleted after environments
	"dataplane",          // Should be deleted after environments
	"project",            // Should be deleted after all components
	"organization",       // Root level resource, deleted last
}
```

