### PR TITLE
Add missing permissions for configurationgroups and configmaps

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,13 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
+  - configmaps
   - namespaces
   - serviceaccounts
   - services
@@ -25,6 +19,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -130,6 +131,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - core.choreo.dev
+  resources:
+  - configurationgroups
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/install/helm/choreo/templates/manager-rbac.yaml
+++ b/install/helm/choreo/templates/manager-rbac.yaml
@@ -8,13 +8,7 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - events
-  verbs:
-  - create
-  - patch
-- apiGroups:
-  - ""
-  resources:
+  - configmaps
   - namespaces
   - serviceaccounts
   - services
@@ -26,6 +20,13 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - patch
 - apiGroups:
   - apps
   resources:
@@ -131,6 +132,14 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - core.choreo.dev
+  resources:
+  - configurationgroups
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - gateway.networking.k8s.io
   resources:

--- a/internal/controller/deployment/controller_rbac.go
+++ b/internal/controller/deployment/controller_rbac.go
@@ -23,9 +23,11 @@ package deployment
 // +kubebuilder:rbac:groups=core.choreo.dev,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core.choreo.dev,resources=deployments/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=core.choreo.dev,resources=deployments/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core.choreo.dev,resources=configurationgroups,verbs=get;list;watch
 // +kubebuilder:rbac:groups=cilium.io,resources=ciliumnetworkpolicies,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=cronjobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=gateway.networking.k8s.io,resources=httproutes,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups="",resources=events,verbs=create;patch


### PR DESCRIPTION
## Purpose
Add missing permissions for configurationgroups and configmaps

## Approach
This PR fixes the RBAC issue in the controller where it need configurationgroup and configmap permissions.

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
