### PR TITLE
Simplify data plane creation interactive flow

### DIFF
--- a/internal/choreoctl/validation/params.go
+++ b/internal/choreoctl/validation/params.go
@@ -288,6 +288,7 @@ func validateDataPlaneParams(cmdType CommandType, params interface{}) error {
 		if p, ok := params.(api.CreateDataPlaneParams); ok {
 			fields := map[string]string{
 				"organization": p.Organization,
+				"name":         p.Name,
 			}
 			if !checkRequiredFields(fields) {
 				return generateHelpError(cmdType, ResourceDataPlane, fields)


### PR DESCRIPTION
## Purpose
This PR improves the interactive mode for creating DataPlanes with the following enhancements:

Added default values for gateway-related fields:

1. gatewayType defaults to "envoy"
2. publicVirtualHost defaults to "choreoapis.local"
3. organizationVirtualHost defaults to "internal.choreoapis.local"

Improved the input prompts in the interactive UI by showing default value suggestions in the prompt text

Pre-filled default values in the model so users can simply press Enter to accept them
