### PR TITLE
Add CLI support for deployment pipeline resource 

### DIFF
--- a/internal/choreoctl/cmd/create/deploymentpipeline/deploymentpipeline.go
+++ b/internal/choreoctl/cmd/create/deploymentpipeline/deploymentpipeline.go
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package deploymentpipeline
+
+import (
+	"fmt"
+
+	"github.com/choreo-idp/choreo/internal/choreoctl/resources/kinds"
+	"github.com/choreo-idp/choreo/internal/choreoctl/validation"
+	"github.com/choreo-idp/choreo/pkg/cli/common/constants"
+	"github.com/choreo-idp/choreo/pkg/cli/types/api"
+)
+
+// CreateDeploymentPipelineImpl implements the CreateDeploymentPipeline command
+type CreateDeploymentPipelineImpl struct {
+	config constants.CRDConfig
+}
+
+// NewCreateDeploymentPipelineImpl creates a new CreateDeploymentPipelineImpl instance
+func NewCreateDeploymentPipelineImpl(config constants.CRDConfig) *CreateDeploymentPipelineImpl {
+	return &CreateDeploymentPipelineImpl{
+		config: config,
+	}
+}
+
+// CreateDeploymentPipeline creates a new deployment pipeline based on provided parameters
+func (i *CreateDeploymentPipelineImpl) CreateDeploymentPipeline(params api.CreateDeploymentPipelineParams) error {
+	if err := validation.ValidateParams(validation.CmdCreate, validation.ResourceDeploymentPipeline, params); err != nil {
+		return err
+	}
+
+	return createDeploymentPipeline(params, i.config)
+}
+
+// createDeploymentPipeline handles the creation of the deployment pipeline resource
+func createDeploymentPipeline(params api.CreateDeploymentPipelineParams, config constants.CRDConfig) error {
+	// Check for empty promotion paths and create a default one if needed
+	if len(params.PromotionPaths) == 0 {
+		// Try to get available environments to create a default promotion path
+		envResource, err := kinds.NewEnvironmentResource(constants.EnvironmentV1Config, params.Organization)
+		if err != nil {
+			return fmt.Errorf("failed to create Environment resource: %w", err)
+		}
+
+		envs, err := envResource.List()
+		if err != nil {
+			return fmt.Errorf("failed to list environments: %w", err)
+		}
+
+		if len(envs) < 2 {
+			return fmt.Errorf("at least two environments are required to create promotion paths")
+		}
+
+		// Create environment order either from provided order or from existing environments
+		var envOrder []string
+
+		if len(params.EnvironmentOrder) >= 2 {
+			// Use user-provided environment order
+			// Validate that the provided environment names actually exist
+			envMap := make(map[string]bool)
+			for _, env := range envs {
+				envMap[env.LogicalName] = true
+			}
+
+			// Verify all environments in order exist
+			for _, envName := range params.EnvironmentOrder {
+				if !envMap[envName] {
+					return fmt.Errorf("environment '%s' specified in environment-order does not exist", envName)
+				}
+			}
+
+			envOrder = params.EnvironmentOrder
+		} else {
+			// Use the first two environments from the available ones
+			// Order by creation timestamp as a sensible default
+			envOrder = []string{
+				envs[0].LogicalName,
+				envs[1].LogicalName,
+			}
+			fmt.Println("No environment order specified. Using default order based on existing environments.")
+		}
+
+		// Create promotion paths based on the standard pattern found in the samples
+		params.PromotionPaths = []api.PromotionPathParams{}
+
+		// For environments in a sequence (like dev → staging → prod)
+		// 1. First environment promotes to all others
+		// 2. Each middle environment promotes to the ones after it
+		for i := 0; i < len(envOrder)-1; i++ {
+			sourceEnv := envOrder[i]
+			targetEnvs := []api.TargetEnvironmentParams{}
+
+			// Add each successive environment as a target
+			for j := i + 1; j < len(envOrder); j++ {
+				// For production targets from any source, require manual approval
+				isProduction := (envOrder[j] == "production" || envOrder[j] == "prod")
+				requiresManualApproval := isProduction && j > i+1 // Skip for direct next environment
+
+				targetEnvs = append(targetEnvs, api.TargetEnvironmentParams{
+					Name:                     envOrder[j],
+					RequiresApproval:         true,
+					IsManualApprovalRequired: requiresManualApproval,
+				})
+			}
+
+			// Add this promotion path
+			params.PromotionPaths = append(params.PromotionPaths, api.PromotionPathParams{
+				SourceEnvironment:  sourceEnv,
+				TargetEnvironments: targetEnvs,
+			})
+		}
+	}
+
+	pipelineRes, err := kinds.NewDeploymentPipelineResource(config, params.Organization)
+	if err != nil {
+		return fmt.Errorf("failed to create DeploymentPipeline resource: %w", err)
+	}
+
+	if err := pipelineRes.CreateDeploymentPipeline(params); err != nil {
+		return fmt.Errorf("failed to create deployment pipeline '%s' in organization '%s': %w",
+			params.Name, params.Organization, err)
+	}
+
+	return nil
+}

--- a/internal/choreoctl/cmd/get/deploymentpipeline/deploymentpipeline.go
+++ b/internal/choreoctl/cmd/get/deploymentpipeline/deploymentpipeline.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package deploymentpipeline
+
+import (
+	"fmt"
+
+	"github.com/choreo-idp/choreo/internal/choreoctl/resources"
+	"github.com/choreo-idp/choreo/internal/choreoctl/resources/kinds"
+	"github.com/choreo-idp/choreo/internal/choreoctl/validation"
+	"github.com/choreo-idp/choreo/pkg/cli/common/constants"
+	"github.com/choreo-idp/choreo/pkg/cli/types/api"
+)
+
+// GetDeploymentPipelineImpl implements the GetDeploymentPipeline command
+type GetDeploymentPipelineImpl struct {
+	config constants.CRDConfig
+}
+
+// NewGetDeploymentPipelineImpl creates a new GetDeploymentPipelineImpl instance
+func NewGetDeploymentPipelineImpl(config constants.CRDConfig) *GetDeploymentPipelineImpl {
+	return &GetDeploymentPipelineImpl{
+		config: config,
+	}
+}
+
+// GetDeploymentPipeline gets deployment pipelines based on the provided parameters
+func (i *GetDeploymentPipelineImpl) GetDeploymentPipeline(params api.GetDeploymentPipelineParams) error {
+	if err := validation.ValidateParams(validation.CmdGet, validation.ResourceDeploymentPipeline, params); err != nil {
+		return err
+	}
+
+	return getDeploymentPipelines(params, i.config)
+}
+
+func getDeploymentPipelines(params api.GetDeploymentPipelineParams, config constants.CRDConfig) error {
+	pipelineRes, err := kinds.NewDeploymentPipelineResource(config, params.Organization)
+	if err != nil {
+		return fmt.Errorf("failed to create DeploymentPipeline resource: %w", err)
+	}
+
+	filter := &resources.ResourceFilter{
+		Name: params.Name,
+	}
+
+	format := resources.OutputFormatTable
+	if params.OutputFormat == constants.OutputFormatYAML {
+		format = resources.OutputFormatYAML
+	}
+
+	return pipelineRes.Print(format, filter)
+}

--- a/internal/choreoctl/impl.go
+++ b/internal/choreoctl/impl.go
@@ -26,6 +26,7 @@ import (
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/dataplane"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/deployableartifact"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/deployment"
+	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/deploymentpipeline"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/deploymenttrack"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/environment"
 	"github.com/choreo-idp/choreo/internal/choreoctl/cmd/create/organization"
@@ -36,6 +37,7 @@ import (
 	getdataplane "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/dataplane"
 	getdeployartifcat "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/deployableartifact"
 	getdeploy "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/deployment"
+	getdeploymentpipeline "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/deploymentpipeline"
 	getdeploymenttrack "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/deploymenttrack"
 	getendpoint "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/endpoint"
 	getenv "github.com/choreo-idp/choreo/internal/choreoctl/cmd/get/environment"
@@ -155,6 +157,11 @@ func (c *CommandImplementation) CreateDeployableArtifact(params api.CreateDeploy
 	return daImpl.CreateDeployableArtifact(params)
 }
 
+func (c *CommandImplementation) CreateDeploymentPipeline(params api.CreateDeploymentPipelineParams) error {
+	dpImpl := deploymentpipeline.NewCreateDeploymentPipelineImpl(constants.DeploymentPipelineV1Config)
+	return dpImpl.CreateDeploymentPipeline(params)
+}
+
 // Delete Operations
 
 func (c *CommandImplementation) Delete(params api.DeleteParams) error {
@@ -218,4 +225,9 @@ func (c *CommandImplementation) SetContext(params api.SetContextParams) error {
 func (c *CommandImplementation) UseContext(params api.UseContextParams) error {
 	configContextImpl := config.NewConfigContextImpl()
 	return configContextImpl.UseContext(params)
+}
+
+func (c *CommandImplementation) GetDeploymentPipeline(params api.GetDeploymentPipelineParams) error {
+	pipelineImpl := getdeploymentpipeline.NewGetDeploymentPipelineImpl(constants.DeploymentPipelineV1Config)
+	return pipelineImpl.GetDeploymentPipeline(params)
 }

--- a/internal/choreoctl/resources/base.go
+++ b/internal/choreoctl/resources/base.go
@@ -248,7 +248,7 @@ func (b *BaseResource[T, L]) PrintTableItems(items []ResourceWrapper[T]) error {
 	}
 
 	// Basic table implementation for any client.Object
-	headers := []string{"NAME", "NAMESPACE", "AGE", "CREATION TIME"}
+	headers := []string{"NAME", "ORGANIZATION", "AGE"}
 	rows := make([][]string, 0, len(items))
 
 	for _, wrapper := range items {
@@ -262,7 +262,6 @@ func (b *BaseResource[T, L]) PrintTableItems(items []ResourceWrapper[T]) error {
 			name,
 			namespace,
 			age,
-			creationTime.Format("2006-01-02 15:04:05"),
 		})
 	}
 

--- a/internal/choreoctl/resources/kinds/deploymentpipeline.go
+++ b/internal/choreoctl/resources/kinds/deploymentpipeline.go
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package kinds
+
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	choreov1 "github.com/choreo-idp/choreo/api/v1"
+	"github.com/choreo-idp/choreo/internal/choreoctl/resources"
+	"github.com/choreo-idp/choreo/internal/controller"
+	"github.com/choreo-idp/choreo/pkg/cli/common/constants"
+	"github.com/choreo-idp/choreo/pkg/cli/types/api"
+)
+
+// DeploymentPipelineResource provides operations for DeploymentPipeline CRs.
+type DeploymentPipelineResource struct {
+	*resources.BaseResource[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList]
+}
+
+// NewDeploymentPipelineResource constructs a DeploymentPipelineResource with CRDConfig and optionally sets organization.
+func NewDeploymentPipelineResource(cfg constants.CRDConfig, org string) (*DeploymentPipelineResource, error) {
+	cli, err := resources.GetClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create Kubernetes client: %w", err)
+	}
+
+	options := []resources.ResourceOption[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList]{
+		resources.WithClient[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList](cli),
+		resources.WithConfig[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList](cfg),
+	}
+
+	// Add organization namespace if provided
+	if org != "" {
+		options = append(options, resources.WithNamespace[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList](org))
+	}
+
+	// Create labels for filtering
+	labels := map[string]string{}
+	if org != "" {
+		labels[constants.LabelOrganization] = org
+	}
+
+	// Add labels if any were set
+	if len(labels) > 0 {
+		options = append(options, resources.WithLabels[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList](labels))
+	}
+
+	return &DeploymentPipelineResource{
+		BaseResource: resources.NewBaseResource[*choreov1.DeploymentPipeline, *choreov1.DeploymentPipelineList](options...),
+	}, nil
+}
+
+// WithNamespace sets the namespace for the deployment pipeline resource (usually the organization name)
+func (d *DeploymentPipelineResource) WithNamespace(namespace string) {
+	d.BaseResource.WithNamespace(namespace)
+}
+
+// GetStatus returns the status of a DeploymentPipeline with detailed information.
+func (d *DeploymentPipelineResource) GetStatus(pipeline *choreov1.DeploymentPipeline) string {
+	// DeploymentPipeline uses the Available condition type
+	priorityConditions := []string{
+		controller.TypeAvailable,
+	}
+
+	return resources.GetResourceStatus(
+		pipeline.Status.Conditions,
+		priorityConditions,
+		StatusPending,
+		StatusReady,
+		StatusFailed,
+	)
+}
+
+// GetAge returns the age of a DeploymentPipeline.
+func (d *DeploymentPipelineResource) GetAge(pipeline *choreov1.DeploymentPipeline) string {
+	return resources.FormatAge(pipeline.GetCreationTimestamp().Time)
+}
+
+// PrintTableItems formats deployment pipelines into a table
+func (d *DeploymentPipelineResource) PrintTableItems(pipelines []resources.ResourceWrapper[*choreov1.DeploymentPipeline]) error {
+	if len(pipelines) == 0 {
+		namespaceName := d.GetNamespace()
+		message := "No deployment pipelines found"
+		if namespaceName != "" {
+			message += " in organization " + namespaceName
+		}
+		fmt.Println(message)
+		return nil
+	}
+
+	rows := make([][]string, 0, len(pipelines))
+
+	for _, wrapper := range pipelines {
+		pipeline := wrapper.Resource
+		rows = append(rows, []string{
+			pipeline.Name,
+			d.GetStatus(pipeline),
+			d.GetAge(pipeline),
+		})
+	}
+
+	headers := []string{"Name", "Status", "Age"}
+	return resources.PrintTable(headers, rows)
+}
+
+// Print overrides the base Print method to ensure our custom PrintTableItems is called
+func (d *DeploymentPipelineResource) Print(format resources.OutputFormat, filter *resources.ResourceFilter) error {
+	return d.BaseResource.Print(format, filter)
+}
+
+// CreateDeploymentPipeline creates a new DeploymentPipeline CR.
+func (d *DeploymentPipelineResource) CreateDeploymentPipeline(params api.CreateDeploymentPipelineParams) error {
+	// Generate a K8s-compliant name for the deployment pipeline
+	k8sName := resources.GenerateResourceName(params.Organization, params.Name)
+
+	// Convert promotion paths from API params to CR structure
+	promotionPaths := []choreov1.PromotionPath{}
+	for _, path := range params.PromotionPaths {
+		targetEnvRefs := []choreov1.TargetEnvironmentRef{}
+		for _, target := range path.TargetEnvironments {
+			targetEnvRefs = append(targetEnvRefs, choreov1.TargetEnvironmentRef{
+				Name:                     target.Name,
+				RequiresApproval:         target.RequiresApproval,
+				IsManualApprovalRequired: target.IsManualApprovalRequired,
+			})
+		}
+
+		promotionPaths = append(promotionPaths, choreov1.PromotionPath{
+			SourceEnvironmentRef:  path.SourceEnvironment,
+			TargetEnvironmentRefs: targetEnvRefs,
+		})
+	}
+
+	// Create the DeploymentPipeline resource
+	deploymentPipeline := &choreov1.DeploymentPipeline{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      k8sName,
+			Namespace: params.Organization,
+			Annotations: map[string]string{
+				constants.AnnotationDisplayName: resources.DefaultIfEmpty(params.DisplayName, params.Name),
+				constants.AnnotationDescription: params.Description,
+			},
+			Labels: map[string]string{
+				constants.LabelName:         params.Name,
+				constants.LabelOrganization: params.Organization,
+			},
+		},
+		Spec: choreov1.DeploymentPipelineSpec{
+			PromotionPaths: promotionPaths,
+		},
+	}
+
+	// Create the deployment pipeline using the base create method
+	if err := d.Create(deploymentPipeline); err != nil {
+		return fmt.Errorf("failed to create deployment pipeline: %w", err)
+	}
+
+	fmt.Printf("Deployment pipeline '%s' created successfully in organization '%s'\n",
+		params.Name, params.Organization)
+	return nil
+}

--- a/internal/choreoctl/resources/kinds/kindconstant.go
+++ b/internal/choreoctl/resources/kinds/kindconstant.go
@@ -132,6 +132,7 @@ const (
 	StatusReady        = "Ready"
 	StatusNotReady     = "Not Ready"
 	StatusInitializing = "Initializing"
+	StatusFailed       = "Failed"
 )
 
 //

--- a/internal/choreoctl/validation/commands.go
+++ b/internal/choreoctl/validation/commands.go
@@ -49,6 +49,7 @@ const (
 	ResourceDataPlane          ResourceType = "dataplane"
 	ResourceLogs               ResourceType = "logs"
 	ResourceApply              ResourceType = "apply"
+	ResourceDeploymentPipeline ResourceType = "deploymentpipeline"
 )
 
 // checkRequiredFields verifies if all required fields are populated

--- a/internal/choreoctl/validation/params.go
+++ b/internal/choreoctl/validation/params.go
@@ -20,6 +20,7 @@ package validation
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/choreo-idp/choreo/pkg/cli/types/api"
 )
@@ -51,6 +52,8 @@ func ValidateParams(cmdType CommandType, resource ResourceType, params interface
 		return validateLogParams(cmdType, params)
 	case ResourceApply:
 		return validateApplyParams(cmdType, params)
+	case ResourceDeploymentPipeline:
+		return validateDeploymentPipelineParams(cmdType, params)
 	default:
 		return fmt.Errorf("unknown resource type: %s", resource)
 	}
@@ -369,6 +372,34 @@ func validateApplyParams(cmdType CommandType, params interface{}) error {
 			}
 			if !checkRequiredFields(fields) {
 				return generateHelpError(cmdType, "", fields)
+			}
+		}
+	}
+	return nil
+}
+
+// Add validation function:
+func validateDeploymentPipelineParams(cmdType CommandType, params interface{}) error {
+	switch cmdType {
+	case CmdGet:
+		if p, ok := params.(api.GetDeploymentPipelineParams); ok {
+			fields := map[string]string{
+				"organization": p.Organization,
+			}
+			if !checkRequiredFields(fields) {
+				return generateHelpError(cmdType, ResourceDeploymentPipeline, fields)
+			}
+		}
+	case CmdCreate:
+		if p, ok := params.(api.CreateDeploymentPipelineParams); ok {
+			fields := map[string]string{
+				"organization":      p.Organization,
+				"name":              p.Name,
+				"environment-order": strings.Join(p.EnvironmentOrder, ","),
+			}
+
+			if !checkRequiredFields(fields) {
+				return generateHelpError(cmdType, ResourceDeploymentPipeline, fields)
 			}
 		}
 	}

--- a/pkg/cli/cmd/create/create.go
+++ b/pkg/cli/cmd/create/create.go
@@ -19,6 +19,8 @@
 package create
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	v1api "github.com/choreo-idp/choreo/api/v1"
@@ -78,6 +80,7 @@ func NewCreateCmd(impl api.CommandImplementationInterface) *cobra.Command {
 		newCreateDeploymentTrackCmd(impl),
 		newCreateEnvironmentCmd(impl),
 		newCreateDeployableArtifactCmd(impl),
+		newCreateDeploymentPipelineCmd(impl),
 	)
 
 	return createCmd
@@ -313,6 +316,36 @@ func newCreateDeployableArtifactCmd(impl api.CommandImplementationInterface) *co
 				Component:       fg.GetString(flags.Component),
 				DeploymentTrack: fg.GetString(flags.DeploymentTrack),
 				Interactive:     fg.GetBool(flags.Interactive),
+			})
+		},
+	}).Build()
+}
+
+func newCreateDeploymentPipelineCmd(impl api.CommandImplementationInterface) *cobra.Command {
+	dpFlags := []flags.Flag{
+		flags.Organization,
+		flags.Name,
+		flags.EnvironmentOrder,
+	}
+
+	return (&builder.CommandBuilder{
+		Command: constants.CreateDeploymentPipeline,
+		Flags:   dpFlags,
+		RunE: func(fg *builder.FlagGetter) error {
+			// Get environment order from flag
+			envOrderStr := fg.GetString(flags.EnvironmentOrder)
+			var environmentOrder []string
+			if envOrderStr != "" {
+				environmentOrder = strings.Split(envOrderStr, ",")
+				for i := range environmentOrder {
+					environmentOrder[i] = strings.TrimSpace(environmentOrder[i])
+				}
+			}
+
+			return impl.CreateDeploymentPipeline(api.CreateDeploymentPipelineParams{
+				Name:             fg.GetString(flags.Name),
+				Organization:     fg.GetString(flags.Organization),
+				EnvironmentOrder: environmentOrder,
 			})
 		},
 	}).Build()

--- a/pkg/cli/cmd/get/get.go
+++ b/pkg/cli/cmd/get/get.go
@@ -249,5 +249,24 @@ func NewListCmd(impl api.CommandImplementationInterface) *cobra.Command {
 	dataPlaneCmd.Args = cobra.MaximumNArgs(1)
 	listCmd.AddCommand(dataPlaneCmd)
 
+	// Deployment Pipeline command
+	deploymentPipelineCmd := (&builder.CommandBuilder{
+		Command: constants.ListDeploymentPipeline,
+		Flags:   []flags.Flag{flags.Organization, flags.Output, flags.Interactive},
+		RunE: func(fg *builder.FlagGetter) error {
+			name := ""
+			if len(fg.GetArgs()) > 0 {
+				name = fg.GetArgs()[0]
+			}
+			return impl.GetDeploymentPipeline(api.GetDeploymentPipelineParams{
+				Name:         name,
+				Organization: fg.GetString(flags.Organization),
+				OutputFormat: fg.GetString(flags.Output),
+			})
+		},
+	}).Build()
+	deploymentPipelineCmd.Args = cobra.MaximumNArgs(1)
+	listCmd.AddCommand(deploymentPipelineCmd)
+
 	return listCmd
 }

--- a/pkg/cli/common/constants/crds.go
+++ b/pkg/cli/common/constants/crds.go
@@ -115,4 +115,9 @@ var (
 		Version: V1,
 		Kind:    "Environment",
 	}
+	DeploymentPipelineV1Config = CRDConfig{
+		Group:   "core.choreo.dev",
+		Version: "v1",
+		Kind:    "DeploymentPipeline",
+	}
 )

--- a/pkg/cli/common/constants/definitions.go
+++ b/pkg/cli/common/constants/definitions.go
@@ -470,6 +470,31 @@ If no organization is specified, you will be prompted to select one interactivel
     --project online-store --component product-catalog --from-image-ref product-catalog:latest`,
 	}
 
+	CreateDeploymentPipeline = Command{
+		Use:     "deploymentpipeline",
+		Aliases: []string{"deppipe", "deppipes", "deploymentpipelines"},
+		Short:   "Create a deployment pipeline",
+		Long:    `Create a deployment pipeline in the specified organization.`,
+		Example: `  # Create a deployment pipeline with specific parameters
+  choreoctl create deploymentpipeline --name dev-stage-prod --organization acme-corp \
+   --environment-order "development,staging,production"`,
+	}
+
+	ListDeploymentPipeline = Command{
+		Use:     "deploymentpipeline [name]",
+		Aliases: []string{"deppipe", "deppipes", "deploymentpipelines"},
+		Short:   "Get deployment pipelines",
+		Long:    `Get all deployment pipelines or a specific deployment pipeline in an organization.`,
+		Example: `  # Get all deployment pipelines
+  choreoctl get deploymentpipeline --organization acme-corp
+
+  # Get a specific deployment pipeline
+  choreoctl get deploymentpipeline default-pipeline --organization acme-corp
+
+  # Get in YAML format
+  choreoctl get deploymentpipeline --organization acme-corp -o yaml`,
+	}
+
 	// ------------------------------------------------------------------------
 	// Config Command Definitions
 	// ------------------------------------------------------------------------

--- a/pkg/cli/common/messages/messages.go
+++ b/pkg/cli/common/messages/messages.go
@@ -78,4 +78,5 @@ const (
 	FlagDeploymentDesc         = "Name of the deployment (e.g., product-catalog-dev-01)"
 	DeleteFileFlag             = "Path to the configuration file to delete (e.g., manifests/deployment.yaml)"
 	FlagWaitDesc               = "Wait for resources to be deleted before returning"
+	FlagEnvironmentOrderDesc   = "Comma-separated list of environment names in promotion order (e.g., dev,staging,prod)"
 )

--- a/pkg/cli/flags/flags.go
+++ b/pkg/cli/flags/flags.go
@@ -284,6 +284,11 @@ var (
 		Shorthand: "f",
 		Usage:     messages.DeleteFileFlag,
 	}
+
+	EnvironmentOrder = Flag{
+		Name:  "environment-order",
+		Usage: messages.FlagEnvironmentOrderDesc,
+	}
 )
 
 // AddFlags adds the specified flags to the given command.

--- a/pkg/cli/types/api/api.go
+++ b/pkg/cli/types/api/api.go
@@ -36,6 +36,7 @@ type CommandImplementationInterface interface {
 	DeploymentTrackAPI
 	EndpointAPI
 	ConfigContextAPI
+	DeploymentPipelineAPI
 }
 
 // OrganizationAPI defines organization-related operations
@@ -122,4 +123,9 @@ type ConfigContextAPI interface {
 	GetCurrentContext() error
 	UseContext(params UseContextParams) error
 	SetContext(params SetContextParams) error
+}
+
+type DeploymentPipelineAPI interface {
+	CreateDeploymentPipeline(params CreateDeploymentPipelineParams) error
+	GetDeploymentPipeline(params GetDeploymentPipelineParams) error
 }

--- a/pkg/cli/types/api/params.go
+++ b/pkg/cli/types/api/params.go
@@ -308,3 +308,29 @@ type SetContextParams struct {
 type UseContextParams struct {
 	Name string
 }
+
+type CreateDeploymentPipelineParams struct {
+	Name             string
+	DisplayName      string
+	Description      string
+	Organization     string
+	PromotionPaths   []PromotionPathParams
+	EnvironmentOrder []string // Ordered list of environment names for promotion path
+}
+
+type PromotionPathParams struct {
+	SourceEnvironment  string
+	TargetEnvironments []TargetEnvironmentParams
+}
+
+type TargetEnvironmentParams struct {
+	Name                     string
+	RequiresApproval         bool
+	IsManualApprovalRequired bool
+}
+
+type GetDeploymentPipelineParams struct {
+	Name         string
+	Organization string
+	OutputFormat string
+}


### PR DESCRIPTION
## Purpose
Add CLI support for deployment pipeline resource.
This is required to create a fresh organization and do all activities from CLI itself without depending on writing manual yaml files. 

## Approach
Basic functionality for create and get operations are supported. 
Interactive mode is not implemented.
