### PR TITLE
Rename Open Source Choreo to OpenChoreo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Source Choreo
+# OpenChoreo
 Internal Developer Platform
 
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
@@ -7,9 +7,9 @@ Internal Developer Platform
 [![GitHub issues](https://img.shields.io/github/issues/choreo-idp/choreo.svg)](https://github.com/choreo-idp/choreo/issues)
 [![Twitter Follow](https://img.shields.io/twitter/follow/Choreo?style=social)](https://twitter.com/ChoreoDev)
 
-## What is Open Source Choreo?
+## What is OpenChoreo?
 
-Open Source Choreo is an internal developer platform (IDP) designed for both platform engineers and developers.
+OpenChoreo is an open-source internal developer platform (IDP) designed for both platform engineers and developers.
 - For platform engineers, Choreo offers a customizable yet fully-featured platform that integrates CI/CD, security, and cloud tools, enforcing best practices while reducing operational overhead.
 - For developers, it abstracts away infrastructure complexities, enabling them to focus on building and deploying applications with minimal friction.
 
@@ -17,33 +17,31 @@ Most organizations face a dilemma when adopting an IDP:
 1. Build their own by integrating multiple tools—offering control but requiring significant engineering effort and maintenance.
 2. Buy a SaaS-based IDP, which simplifies adoption but often limits customization and flexibility.
 
-Open Source Choreo provides a third path—a self-hosted, open-source IDP that delivers production-grade capabilities out of the box without sacrificing control or flexibility.
+OpenChoreo provides a third path—a self-hosted, open-source IDP that delivers production-grade capabilities out of the box without sacrificing control or flexibility.
 
 [//]: # (Architecture Diagram)
 
 ## Inspired by WSO2 Choreo SaaS
 
-Open Source Choreo is inspired by **[WSO2 Choreo SaaS](https://choreo.dev/)**, an enterprise-grade internal developer platform that has been adopted by organizations to streamline software delivery and engineering.
+OpenChoreo is inspired by **[WSO2 Choreo SaaS](https://choreo.dev/)**, an enterprise-grade internal developer platform that has been adopted by organizations to streamline software delivery and engineering.
 
 WSO2 Choreo SaaS provides a complete IDP experience, combining:
 
 - Software Delivery – Seamless workflows to build, deploy, run, and manage applications at scale.
 - Software Engineering – Advanced capabilities for API management, modularity, service reuse, and observability.
 
-With Open Source Choreo, we are bringing these capabilities to the open-source community—allowing organizations to run, extend, and customize an internal developer platform on their own infrastructure, while [WSO2 Choreo SaaS](https://choreo.dev/) remains a fully managed alternative.
+With OpenChoreo, we are bringing these capabilities to the open-source community—allowing organizations to run, extend, and customize an internal developer platform on their own infrastructure, while [WSO2 Choreo SaaS](https://choreo.dev/) remains a fully managed alternative.
 
 
 ## Getting Started
 
-The easiest way to try Open Source Choreo is by following the **[Quick Start Guide](./docs/quick-start-guide.md)**. It walks you through setting up Choreo using a Dev Container, so you can start experimenting without affecting your local environment.
+The easiest way to try OpenChoreo is by following the **[Quick Start Guide](./docs/quick-start-guide.md)**. It walks you through setting up Choreo using a Dev Container, so you can start experimenting without affecting your local environment.
 
-If you prefer to set up Choreo on your local machine from scratch, check out our **[Installation Guide](./docs/install/install-choreo.md)**.
-
-For a deeper understanding on Open Source Choreo’s architecture, see **[Choreo Concepts](./docs/choreo-concepts.md)**.
+For a deeper understanding of OpenChoreo’s architecture, see **[Choreo Concepts](./docs/choreo-concepts.md)**.
 
 ## Samples
 
-Explore hands-on examples to help you configure and deploy applications using Open Source Choreo.
+Explore hands-on examples to help you configure and deploy applications using OpenChoreo.
 
 - **[Configuring Choreo](./samples/configuring-choreo/)** – Set up organizations, environments, data planes, and deployment pipelines.
 - **[Deploying Applications](./samples/deploying-applications/)** – Deploy services, web apps, and scheduled tasks.
@@ -52,7 +50,7 @@ Check out the **[Samples Directory](./samples/)** for more details.
 
 ## Join the Community & Contribute
 
-We’d love for you to be part of Open Source Choreo’s journey! 
+We’d love for you to be part of OpenChoreo’s journey! 
 Whether you’re fixing a bug, improving documentation, or suggesting new features, every contribution counts.
 
 - **[Contributor Guide](./docs/contributors/README.md)** – Learn how to get started.
@@ -62,8 +60,8 @@ Whether you’re fixing a bug, improving documentation, or suggesting new featur
 We’re excited to have you onboard!
 
 ## Roadmap
-Explore the Open Source Choreo roadmap, including completed milestones and upcoming plans, in our **[Roadmap]( https://github.com/orgs/choreo-idp/projects/1)**.
+Explore the OpenChoreo roadmap, including completed milestones and upcoming plans, in our **[Roadmap]( https://github.com/orgs/choreo-idp/projects/1)**.
 
 ## License
-Open Source Choreo is licensed under Apache 2.0. See the **[LICENSE](./LICENSE)** file for full details.
+OpenChoreo is licensed under Apache 2.0. See the **[LICENSE](./LICENSE)** file for full details.
 

--- a/docs/choreo-concepts.md
+++ b/docs/choreo-concepts.md
@@ -1,4 +1,4 @@
-# Open Source Choreo Concepts
+# OpenChoreo Concepts
 
 This repository defines Choreo abstractions in the form of Kubernetes CRDs, enabling developers to use these abstractions to create projects, components, builds, deployments, and more. By leveraging these CRDs, developers can declaratively manage their application's lifecycle and infrastructure, ensuring consistency and repeatability across environments.
 

--- a/docs/contributors/README.md
+++ b/docs/contributors/README.md
@@ -1,6 +1,6 @@
-# Contributing to Open Source Choreo
+# Contributing to OpenChoreo
 
-Welcome! We're excited that you're interested in contributing to Open Source Choreo. Whether you're fixing a bug, improving documentation, or proposing new features, every contribution makes a difference.
+Welcome! We're excited that you're interested in contributing to OpenChoreo. Whether you're fixing a bug, improving documentation, or proposing new features, every contribution makes a difference.
 
 ## Getting Started
 
@@ -8,10 +8,10 @@ Before you start contributing, check out our guidelines:
 
 - **[Contribution Guide](./contributing.md)** – Learn how to submit changes, report issues, and follow best practices.
 - **[GitHub Workflow](./GitHub_workflow.md)** – Understand our GitHub workflow for submitting pull requests.
-- **[Resource Kind Reference Guide](./resource-kind-reference-guide.md)** – Get details about resource kinds in Open Source Choreo.
+- **[Resource Kind Reference Guide](./resource-kind-reference-guide.md)** – Get details about resource kinds in OpenChoreo.
 
 ## Need Help?
 
 If you have any questions, join our **[Discord Community](https://discord.gg/HYCgUacN)** or open a **[GitHub Discussion](https://github.com/choreo-idp/choreo/discussions)**.
 
-We appreciate your contributions—thank you for making Open Source Choreo better! 
+We appreciate your contributions—thank you for making OpenChoreo better! 

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -1,7 +1,7 @@
 ## Quick Start Guide
 
-Setting up Open Source Choreo in a Kubernetes cluster involves multiple steps and tools. This guide provides a fast and simple way to install a fully functional Open Source Choreo instance on your local machine with minimal prerequisites and effort by using a pre-configured dev container.
-This dev container has all the necessary tools installed for setting up Open Source Choreo and is ready to be used. Once the installation is complete, you can explore the underlying setup to understand how it works.
+Setting up OpenChoreo in a Kubernetes cluster involves multiple steps and tools. This guide provides a fast and simple way to install a fully functional OpenChoreo instance on your local machine with minimal prerequisites and effort by using a pre-configured dev container.
+This dev container has all the necessary tools installed for setting up OpenChoreo and is ready to be used. Once the installation is complete, you can explore the underlying setup to understand how it works.
 When you're done, you can fully clean up the setup, leaving your machine clutter-free.
 
 #### Prerequisites
@@ -27,8 +27,8 @@ ghcr.io/choreo-idp/quick-start:v0.1.0
 
 ```
 
-#### Install Open Source Choreo
-This process sets up a [KinD](https://kind.sigs.k8s.io/) (Kubernetes-in-Docker) cluster in your Docker environment and installs Open Source Choreo along with its dependencies.
+#### Install OpenChoreo
+This process sets up a [KinD](https://kind.sigs.k8s.io/) (Kubernetes-in-Docker) cluster in your Docker environment and installs OpenChoreo along with its dependencies.
 
 To begin the installation, run:
 
@@ -60,9 +60,9 @@ Overall Status: ✅ READY
 🎉 Choreo has been successfully installed and is ready to use!
 ```
 
-#### Deploying a Web Application with Open Source Choreo
+#### Deploying a Web Application with OpenChoreo
 
-You now have Open Source Choreo fully setup in your docker environment.
+You now have OpenChoreo fully setup in your docker environment.
 Next, lets deploy a sample Web Application by running the following command:
 
 ```shell
@@ -77,15 +77,15 @@ Once the deployment is complete, you will receive the following message together
 ```
 
 ### Understanding What Happens Behind the Scenes
-By following the install and deploy web application commands, you first, setup Open Source Choreo and then, successfully deployed and accessed a fully functional Web Application.
+By following the install and deploy web application commands, you first, setup OpenChoreo and then, successfully deployed and accessed a fully functional Web Application.
 
 Let’s now explore what happens after each command.
 
 #### 1. The Install Command
-- A dev container with all the necessary tools for Open Source Choreo to run is set up in a local Docker environment.
-- A KinD Kubernetes cluster is created, where the Open Source Choreo IDP and its dependencies were installed using Helm charts.
+- A dev container with all the necessary tools for OpenChoreo to run is set up in a local Docker environment.
+- A KinD Kubernetes cluster is created, where the OpenChoreo IDP and its dependencies were installed using Helm charts.
 
-#### Foundation Resources Created by Open Source Choreo
+#### Foundation Resources Created by OpenChoreo
 
 The installation process, by default, sets up several essential abstractions. These are:
 - Organization
@@ -94,7 +94,7 @@ The installation process, by default, sets up several essential abstractions. Th
 - [Deployment Pipeline](https://github.com/choreo-idp/choreo/tree/main/docs#deploymentpipeline) for the environments
 - [Project](https://github.com/choreo-idp/choreo/tree/main/docs#project)
 
-To access the artifacts created in Open Source Choreo you can use choreoctl as shown in the following commands:
+To access the artifacts created in OpenChoreo you can use choreoctl as shown in the following commands:
 
 First you can get the current context
 ```shell
@@ -132,7 +132,7 @@ choreoctl get components
 choreoctl get deployment --component react-starter-image
 ```
 
-Open Source Choreo generates a [DeployableArtifact](https://github.com/choreo-idp/choreo/tree/main/docs#deployableartifact) and an [Endpoint](https://github.com/choreo-idp/choreo/tree/main/docs#endpoint) to access the running application:
+OpenChoreo generates a [DeployableArtifact](https://github.com/choreo-idp/choreo/tree/main/docs#deployableartifact) and an [Endpoint](https://github.com/choreo-idp/choreo/tree/main/docs#endpoint) to access the running application:
 
 ```shell
 choreoctl get deployableartifact --component react-starter-image
@@ -169,4 +169,4 @@ After finishing your work, you have two options:
 
 That's it!
 
-Now you understand how Open Source Choreo simplifies the deployment and management of cloud-native applications.
+Now you understand how OpenChoreo simplifies the deployment and management of cloud-native applications.

--- a/install/helm/choreo/Chart.yaml
+++ b/install/helm/choreo/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: choreo
-description: A Helm chart for choreo open source dataplane
+description: A Helm chart for choreo open dataplane
 # A chart can be either an 'application' or a 'library' chart.
 #
 # Application charts are a collection of templates that can be packaged into versioned archives

--- a/pkg/cli/common/messages/messages.go
+++ b/pkg/cli/common/messages/messages.go
@@ -23,7 +23,7 @@ const (
 
 	DefaultCLIName             = "choreoctl"
 	DefaultCLIShortDescription = "Welcome to Choreo CLI, " +
-		"the command-line interface for Open Source Choreo - Internal Developer Platform"
+		"the command-line interface for OpenChoreo - Internal Developer Platform"
 
 	// Common prefix for errors
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -1,27 +1,27 @@
-# Open Source Choreo Samples
-This directory contains sample implementations to help you understand, configure, and use Open Source Choreo effectively. These samples cover different use cases, from setting up platform configurations to deploying applications in various environments.
+# OpenChoreo Samples
+This directory contains sample implementations to help you understand, configure, and use OpenChoreo effectively. These samples cover different use cases, from setting up platform configurations to deploying applications in various environments.
 
 ## Categories
 We have categorized the samples based on what you might want to do: 
-- **[Configuring Open Source Choreo](./configuring-choreo)** - Define and customize foundational platform elements such as organizations, environments, and deployment pipelines according to your organization needs.
+- **[Configuring OpenChoreo](./configuring-choreo)** - Define and customize foundational platform elements such as organizations, environments, and deployment pipelines according to your organization needs.
 - **[Deploying Applications](./deploying-applications)** - Deploy different types of applications (services, APIs, web apps, tasks) using various programming languages.
 
 
-## Configuring Open Source Choreo
-When you set up Open Source Choreo, certain default resources are automatically created to help you get started quickly:
+## Configuring OpenChoreo
+When you set up OpenChoreo, certain default resources are automatically created to help you get started quickly:
 - A default organization
 - A default data plane
 - Three default environments (Dev, Staging, Prod)
 - A default deployment pipeline connecting these environments
 - A default project to organize applications
 
-Open Source Choreo provides abstractions to define:
+OpenChoreo provides abstractions to define:
 - Organizations – Manage access and group related projects.
 - Environments – Set up Dev, Staging, and Prod environments.
 - Data Planes – Define Kubernetes clusters for application deployments.
 - Deployment Pipelines – Automate application rollouts.
 
-For more details on these concepts, refer to the [Open Source Choreo Abstractions](../docs/choreo-concepts.md) Document.
+For more details on these concepts, refer to the [OpenChoreo Abstractions](../docs/choreo-concepts.md) Document.
 
 These default configurations provide a quick starting point. Once you have done some exploration you can start creating the necessary artifacts to match the needs of your organization. You can;
 
@@ -32,7 +32,7 @@ These default configurations provide a quick starting point. Once you have done 
  
 
 ## Deploying Applications
-These samples help you deploy different types of applications using Open Source Choreo. All samples refer to the default setup.
+These samples help you deploy different types of applications using OpenChoreo. All samples refer to the default setup.
 
 
 ### Component Types
@@ -41,7 +41,7 @@ These samples help you deploy different types of applications using Open Source 
 - [Tasks](./deploying-applications/build-from-source/time-logger-task) – Background jobs or scheduled tasks.
 
 ### Supported Languages (via BuildPacks)
-Open Source Choreo abstracts the build and deployment process using BuildPacks, enabling developers to deploy applications written in:
+OpenChoreo abstracts the build and deployment process using BuildPacks, enabling developers to deploy applications written in:
 - [Ballerina](./deploying-applications/languages/ballerina)
 - [Go](./deploying-applications/languages/go)
 - [Node.js](./deploying-applications/languages/node-js)
@@ -55,4 +55,4 @@ Open Source Choreo abstracts the build and deployment process using BuildPacks, 
 ### Project Creation
 All the above sample components uses the default project. Follow this [sample](./deploying-applications/add-new-project) to create a new project if required.   
 
-Note: In case you need to try these application samples in a new configuration remember to use the new resource names you created while following the "Configuring Open Source Choreo" section above.
+Note: In case you need to try these application samples in a new configuration remember to use the new resource names you created while following the "Configuring OpenChoreo" section above.


### PR DESCRIPTION
We thought of making this change to align with contemporary naming conventions.