### PR TITLE
Fix failing deployment context creation due to config groups

### DIFF
--- a/internal/controller/deployment/deployment_context.go
+++ b/internal/controller/deployment/deployment_context.go
@@ -249,6 +249,10 @@ func (r *Reconciler) findConfigurationGroups(ctx context.Context, deployableArti
 		configGroupNames = append(configGroupNames, name)
 	}
 
+	if len(configGroupNames) == 0 {
+		return nil, nil
+	}
+
 	req, err := k8slabels.NewRequirement(labels.LabelKeyName, selection.In, configGroupNames)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build the label selector: %w", err)


### PR DESCRIPTION
## Purpose
Fix failing deployment context creation due to config groups

## Approach
This PR fixes the issue where it fails to create the deployment context when no configuration groups are mapped 

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
