### PR TITLE
Fix slash before port in qs generated url

### DIFF
--- a/install/quick-start/deploy_web_application.sh
+++ b/install/quick-start/deploy_web_application.sh
@@ -59,6 +59,7 @@ while true; do
 
   if [[ "$READY_CONDITION" == "True" ]]; then
     ENDPOINT_URL=$(kubectl get endpoints.core.choreo.dev "$ENDPOINT_NAME" -n "$NAMESPACE" -o jsonpath="{.status.address}")
+    ENDPOINT_URL="${ENDPOINT_URL%/}
     echo "✅ Endpoint is ready!"
     echo "🌍 You can now access the Sample Web Application at: $ENDPOINT_URL:8443"
     break


### PR DESCRIPTION
## Purpose
Fix slash before port in qs generated url

## Approach
Remove the trailing slash in the generated URL (Ex: `https://react-starter-image-development.choreoapps.localhost/:8443`

## Related Issues
> Include any related issues that are resolved by this PR.

## Checklist
- [ ] Tests added or updated (unit, integration, etc.)
- [ ] Samples updated (if applicable)

## Remarks
> Add any additional context, known issues, or TODOs related to this PR.
